### PR TITLE
Add amd64 support and dynamic architecture selection for SnapFrame add‑on

### DIFF
--- a/snapframe/Dockerfile
+++ b/snapframe/Dockerfile
@@ -1,3 +1,4 @@
+ARG BUILD_ARCH
 FROM ghcr.io/home-assistant/${BUILD_ARCH}-base:3.20
 
 RUN apk add --no-cache \

--- a/snapframe/Dockerfile
+++ b/snapframe/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/home-assistant/aarch64-base:3.20
+FROM ghcr.io/home-assistant/${BUILD_ARCH}-base:3.20
 
 RUN apk add --no-cache \
     python3 \

--- a/snapframe/config.yaml
+++ b/snapframe/config.yaml
@@ -1,8 +1,8 @@
 name: "SnapFrame – Digital Photo Frame"
-version: "2.9.2"
-slug: "snapframe-dev"
+version: "2.9.1"
+slug: "snapframe"
 description: "Turn any old tablet or iPad into a smart digital photo frame. Watches an SMB share, converts HEIC/HEIF to JPG, and serves a fullscreen slideshow with albums, EXIF date/GPS overlay, swipe gestures, web upload, night mode and a motion-triggered weather screen."
-url: "https://github.com/davidrule1969/ha-snapframe"
+url: "https://github.com/emo546/ha-snapframe"
 arch:
   - aarch64
   - amd64

--- a/snapframe/config.yaml
+++ b/snapframe/config.yaml
@@ -2,7 +2,7 @@ name: "SnapFrame – Digital Photo Frame"
 version: "2.9.2"
 slug: "snapframe-dev"
 description: "Turn any old tablet or iPad into a smart digital photo frame. Watches an SMB share, converts HEIC/HEIF to JPG, and serves a fullscreen slideshow with albums, EXIF date/GPS overlay, swipe gestures, web upload, night mode and a motion-triggered weather screen."
-url: "https://github.com/emo546/ha-snapframe"
+url: "https://github.com/davidrule1969/ha-snapframe"
 arch:
   - aarch64
   - amd64

--- a/snapframe/config.yaml
+++ b/snapframe/config.yaml
@@ -1,6 +1,6 @@
 name: "SnapFrame – Digital Photo Frame"
-version: "2.9.1"
-slug: "snapframe"
+version: "2.9.2"
+slug: "snapframe-dev"
 description: "Turn any old tablet or iPad into a smart digital photo frame. Watches an SMB share, converts HEIC/HEIF to JPG, and serves a fullscreen slideshow with albums, EXIF date/GPS overlay, swipe gestures, web upload, night mode and a motion-triggered weather screen."
 url: "https://github.com/emo546/ha-snapframe"
 arch:


### PR DESCRIPTION
**Fixes**

- Installation failure on x86_64 systems

**Changes**

- Dockerfile updated to use dynamic base image via BUILD_ARCH