### PR TITLE
Waste collection calendar with day-before reminders (v2.10.0)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "attribution": {
+    "commit": "",
+    "sessionUrl": false
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
           pip install --quiet ruff
           ruff check --select E9,F63,F7,F82 --target-version py312 \
             snapframe/rootfs/usr/bin
+      - name: Unit tests
+        run: python -m unittest discover -s tests -v
 
   build:
     name: Build ${{ matrix.arch }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,7 @@ Thumbs.db
 *.zip
 *.tar.gz
 
-# Claude Code local settings
-.claude/
+# Claude Code – personal/local settings stay out of git, but the shared
+# project settings (attribution: no Co-Authored-By trailer) are versioned
+.claude/*
+!.claude/settings.json

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ You can display your family photos, organize them into albums, show photo inform
 | 🌙 **Night mode**                 | Automatically switch the display to night mode during the night |
 | 🌤️ **Weather mode**              | Show weather information when triggered               |
 | 🗑️ **Waste collection reminders** | Know the day before which bin to put out               |
+| 📄 **Schedule import**            | Upload the municipal leaflet, dates are read out of it |
 | 🏠 **Home Assistant integration** | Control SnapFrame using Home Assistant                |
 | 🌍 **Multi-language UI**          | Use SnapFrame in different languages                  |
 | 📱 **Old hardware friendly**      | Give an old tablet a new purpose                      |
@@ -180,7 +181,6 @@ It's open source and I'm continuing to improve it.
 Some things I'd like to explore:
 
 * [ ] More Home Assistant controls
-* [ ] Calendar import for waste collection schedules (ICS)
 * [ ] More display modes
 * [ ] Better tablet power management
 * [ ] More customization options

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You can display your family photos, organize them into albums, show photo inform
 | 📅 **EXIF information**           | Display photo date and GPS information                |
 | 🌙 **Night mode**                 | Automatically switch the display to night mode during the night |
 | 🌤️ **Weather mode**              | Show weather information when triggered               |
+| 🗑️ **Waste collection reminders** | Know the day before which bin to put out               |
 | 🏠 **Home Assistant integration** | Control SnapFrame using Home Assistant                |
 | 🌍 **Multi-language UI**          | Use SnapFrame in different languages                  |
 | 📱 **Old hardware friendly**      | Give an old tablet a new purpose                      |
@@ -67,6 +68,10 @@ For example:
 Or:
 
 **Night time → switch to night mode**
+
+Or:
+
+**Tomorrow is bin day → remind me on the frame (and on my phone)**
 
 Or:
 
@@ -175,6 +180,7 @@ It's open source and I'm continuing to improve it.
 Some things I'd like to explore:
 
 * [ ] More Home Assistant controls
+* [ ] Calendar import for waste collection schedules (ICS)
 * [ ] More display modes
 * [ ] Better tablet power management
 * [ ] More customization options

--- a/snapframe/CHANGELOG.md
+++ b/snapframe/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - New config option: `anthropic_api_key` (optional, empty by default).
 - New endpoint: `POST /waste/import` (returns detected series; saves nothing).
 - 15 further unit tests covering the parser, built on generated PDFs whose marked days are known exactly.
+- Documentation: a full *Importing the municipal schedule* section, troubleshooting entries for a schedule that can't be read or whose colours map to the wrong type, and security notes covering the one optional feature that can send data off your network.
 
 ### Fixed
 - The grid-cell radius used when matching colour marks to days is now derived from the page's own row/column pitch instead of a fixed point value, so the same schedule laid out at a different page size no longer risks attaching a mark to the neighbouring day.

--- a/snapframe/CHANGELOG.md
+++ b/snapframe/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.10.0] – 2026
+
+### Added
+- **Waste collection calendar** – set up which days of the year each waste type is collected (mixed, bio, plastic, paper, glass, metal, drink cartons, e-waste, bulky, other) and the frame reminds you the day before, so the bin actually makes it to the kerb.
+  - **Rules, not endless date lists.** Real municipal schedules are almost always *"every other Thursday"* or *"first Monday of the month"*, so a collection is defined as a rule: **every N weeks** on a weekday (with a reference date that fixes which week is the right one), **monthly** by position (*first / last Monday…*, optionally limited to certain months) or by day number, or a plain **list of specific dates** for irregular pickups. Every rule can additionally have a validity range (*valid from / until*), **exceptions** (public holidays – no collection) and **extra one-off dates**.
+  - **Two reminder styles, configurable** – a discreet **corner badge** shown on top of the photos the whole time, a **full-screen reminder** injected every *N* photos (same pattern as the weather screen), or both at once.
+  - **Configurable lead time** – remind 0–7 days ahead, optionally also on the collection day itself, and optionally only from a given hour (so the "tomorrow" reminder doesn't nag from 6 a.m.).
+  - **Set up entirely in the app** – a full editor behind Settings → *Waste collection…*, so no add-on restart and no hand-editing YAML with dozens of dates. The schedule is stored in `/data/waste_schedule.json` and shared by every tablet pointed at the add-on.
+  - The frame decides what "tomorrow" means using the *tablet's* local time, not the container's – the server only ships the expanded list of upcoming collection days, so a container running in UTC can't shift the reminder by a day.
+- New endpoints: `GET`/`POST` `/waste/config`, `GET /waste/status`, and `GET /waste/next` – the last one is shaped for a Home Assistant REST sensor (`state` is the next collection date, with `days_until` and the waste types), so you can also send a phone notification or drive automations from the same schedule.
+- Slovak, English and German translations for the whole feature, including waste-type names and human-readable rule summaries.
+- **Unit tests** for the schedule engine (`tests/test_waste.py`, 30 cases covering recurrence phases, month-edge cases, exceptions/extras and config sanitisation) plus a CI step that runs them.
+
+### Changed
+- The weather screen and the waste reminder never overlap: while the weather screen is up (or during night mode, or outside the slideshow) the corner badge stays hidden, and each keeps its own photo counter so both interleave cleanly.
+
 ## [2.9.1] – 2026
 
 ### Fixed

--- a/snapframe/CHANGELOG.md
+++ b/snapframe/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.11.0] – 2026
+
+### Added
+- **Import the municipal collection schedule from a file** – upload the leaflet in the app (Settings → *Waste collection…* → *"Import from schedule…"*) and SnapFrame reads the collection dates out of it, instead of you typing a year's worth of dates by hand.
+  - **Vector PDFs are parsed locally – no OCR, no network, no API key.** Municipal schedules are grid calendars where the meaning is carried by the *colour of the cell*, not by text: OCR would return the day numbers with no idea which of them are collections. A vector PDF, though, contains both the day numbers and the coloured rectangles with their coordinates, so they can be matched directly. Row = ISO week number and column = weekday, so **(ISO week + weekday) gives the exact date**, and the printed day number is then used as a checksum — a cell that doesn't agree is discarded rather than guessed.
+  - **Detects series, not waste types.** The palette is deliberately not hard-coded: one village marks plastic yellow, the next marks it blue, and the *same* leaflet routinely carries several schedules at once (a fortnightly and a monthly mixed-waste round, for instance) — which one applies to a given household is something only the resident knows. The import lists every colour series it found, with a swatch, how often it recurs and its date range, and you tick the ones that apply and assign each a waste type.
+  - **Understands cell outlines.** A coloured border around a cell marks a subset or an add-on rather than a separate waste type (on a real leaflet: a green outline on a black cell = the monthly-frequency round, a brown outline on a yellow cell = "bio *and* plastic on the same day"). Both the per-colour total and the exact fill/outline combination are offered, so either reading can be picked.
+  - **Nothing is ever saved automatically** – the parsed dates land in the editor for confirmation first. A misread date means a missed bin, which is precisely what this feature exists to prevent.
+  - Concrete dates are imported rather than an inferred recurrence rule, so real-world exceptions survive: a fortnightly round that skips New Year's Eve stays skipped instead of producing a phantom reminder.
+- **Optional fallback for scans and photos** – if the layout isn't one the parser recognises, or you upload a JPG/PNG instead of a vector PDF, SnapFrame can send the file to Claude to extract the dates. This is **off unless you set `anthropic_api_key`**, and it is the only path in SnapFrame that sends anything outside your network — the parser above needs no key and no internet.
+- New config option: `anthropic_api_key` (optional, empty by default).
+- New endpoint: `POST /waste/import` (returns detected series; saves nothing).
+- 15 further unit tests covering the parser, built on generated PDFs whose marked days are known exactly.
+
+### Fixed
+- The grid-cell radius used when matching colour marks to days is now derived from the page's own row/column pitch instead of a fixed point value, so the same schedule laid out at a different page size no longer risks attaching a mark to the neighbouring day.
+
 ## [2.10.0] – 2026
 
 ### Added

--- a/snapframe/Dockerfile
+++ b/snapframe/Dockerfile
@@ -13,7 +13,9 @@ RUN pip3 install --break-system-packages --no-cache-dir \
     pillow \
     pillow-heif \
     flask \
-    waitress
+    waitress \
+    pdfplumber \
+    anthropic
 
 COPY rootfs /
 

--- a/snapframe/README.md
+++ b/snapframe/README.md
@@ -17,6 +17,7 @@ If you have a retired iPad, an old Android tablet, or any spare touchscreen gath
 - ⬆️ **Web upload** – upload photos directly from a phone's browser without needing SMB access; supports multiple files and creating new albums on the fly
 - 🌤️ **Motion-triggered weather screen** – trigger "weather mode" from a Home Assistant motion sensor (e.g. in the morning) so the slideshow inserts a nicely designed current-weather + today's forecast screen every few photos
 - 🗑️ **Waste collection reminders** – set up your municipal collection calendar in the app (every other Thursday, first Monday of the month, or plain dates) and the frame reminds you the day before which bin goes out — as a corner badge on the photos, a full-screen reminder every few photos, or both
+- 📄 **Schedule import** – upload the municipal collection leaflet and SnapFrame reads the dates straight out of the PDF, locally, with no OCR and no API key
 - 🌙 **Night mode** – configurable sleep schedule blanks the screen (plain black or an animated starry sky) to save your display and avoid a glowing photo frame at 3am
 - 🌍 **Multi-language UI** – Slovak, English, and German out of the box
 - ⚙️ **In-app settings** – night-mode theme can be changed directly from the slideshow, no need to touch the Home Assistant add-on configuration
@@ -129,6 +130,7 @@ You can also embed it as an `iframe` panel in your Lovelace dashboard if you'd r
 | `sleep_end` | *(empty)* | Night mode end time, e.g. `07:00`; leave empty to disable |
 | `weather_photo_interval` | `8` | How many photos to show between weather screens while weather mode is active (2–50) |
 | `weather_mode_duration_minutes` | `120` | How long weather mode stays active after being triggered via `/weather-mode/on` (5–720) |
+| `anthropic_api_key` | `""` | **Optional.** Enables reading a collection schedule from a photo/scan when the local PDF parser can't handle it. Leave empty to keep everything on your own network — see [Importing the municipal schedule](#importing-the-municipal-schedule) |
 
 ### Example configuration
 
@@ -153,6 +155,7 @@ sleep_start: "23:00"
 sleep_end: "07:00"
 weather_photo_interval: 8
 weather_mode_duration_minutes: 120
+anthropic_api_key: ""
 ```
 
 Most of the above (except SMB credentials) can also be changed later — night-mode theme (black vs. starry sky) is even adjustable directly from the slideshow via the ⚙ settings icon, without touching the add-on config at all.
@@ -269,6 +272,34 @@ And under the timing options:
 The reminder is hidden while the weather screen is showing, during night mode, and outside the slideshow.
 
 > **Time zones:** the add-on only ships the *list of upcoming collection days*; the tablet's browser decides what "today" and "tomorrow" mean using its own local time. A container running in UTC therefore can't shift your reminder by a day.
+
+### Importing the municipal schedule
+
+Typing a year of collection dates by hand is the thing that makes a feature like this get abandoned, so the schedule can be read straight out of the leaflet your municipality hands out. In the waste calendar editor tap **"Import from schedule…"** and upload the file.
+
+**Vector PDFs are parsed on the add-on itself — no OCR, no network, no API key.** These schedules are grid calendars in which the meaning is carried by the *colour of the cell*, not by any text; OCR would hand back the day numbers with no idea which of them are collections. A vector PDF contains both the day numbers and the coloured rectangles together with their coordinates, so the two can be matched directly. Rows are numbered by ISO week and columns are weekdays, so **(ISO week + weekday) yields the exact date** — the month blocks never have to be identified at all — and the printed day number then acts as a checksum: a cell whose number disagrees is dropped rather than guessed.
+
+What you get back is a list of **series**, not finished waste types:
+
+| Why | What it means for you |
+|---|---|
+| Palettes differ between municipalities | Nothing is hard-coded to one village's colours; the importer reports whatever colours it finds |
+| One leaflet often carries several schedules | A fortnightly *and* a monthly mixed-waste round can both be printed on the same page — only you know which applies to your household |
+| Outlines mark variants, not new types | A green border on a black cell can mean "monthly round"; a brown border on a yellow cell can mean "bio *and* plastic that day". Both the per-colour total and the exact fill/outline combination are offered |
+
+Each series is shown with its colour swatch, how often it repeats (e.g. *"every 2 weeks · Thursday"*), how many dates it has and the range they span. Tick the ones that apply to you, pick a waste type for each, and add them.
+
+> **Nothing is saved automatically.** The parsed dates go into the editor for you to confirm first — a misread date means a missed bin, which is exactly what this feature exists to prevent.
+
+Concrete dates are imported rather than a guessed recurrence rule, so real-world exceptions survive intact: if the fortnightly round skips New Year's Eve, it stays skipped instead of generating a phantom reminder.
+
+#### Scans and photos (optional, off by default)
+
+If you upload a photo or scan, or the PDF's layout isn't one the parser recognises, SnapFrame can fall back to sending the file to Claude to extract the dates. This requires the optional `anthropic_api_key` option and is **disabled unless you set it**.
+
+> This fallback is the only part of SnapFrame that sends anything outside your network. The PDF parser above needs no key and no internet, so if your municipality publishes a normal vector PDF you never need this.
+
+---
 
 ### Using the schedule in Home Assistant
 
@@ -441,6 +472,7 @@ To turn weather mode off early (e.g. from another automation, or a script tied t
 | `POST` | `/waste/config` | Replace the waste calendar config (JSON body; validated and clamped server-side) |
 | `GET` | `/waste/status` | Display settings + expanded collection days for the next ~3 weeks |
 | `GET` | `/waste/next` | Next collection — shaped for a Home Assistant REST sensor |
+| `POST` | `/waste/import` | Extract collection series from an uploaded schedule (`multipart/form-data`: `file`); returns a proposal, saves nothing |
 
 ### `/status` response example
 

--- a/snapframe/README.md
+++ b/snapframe/README.md
@@ -587,6 +587,16 @@ EXIF metadata is read from the JPG files. GPS coordinates are reverse-geocoded v
 - SnapFrame's server-side code copies whatever EXIF it's given untouched, so this cannot be fixed from the add-on side — it happens on the device before the file ever reaches SnapFrame.
 - Workaround: upload those photos via the SMB share instead (copy from Files/Finder, or drag-and-drop onto the share), or AirDrop them to a computer first and copy from there — both preserve the original file, including full-precision GPS.
 
+**Schedule import finds nothing / "No collection calendar could be found"**
+- The parser reads **vector** PDFs — the kind your municipality generates from a spreadsheet or design tool. A PDF that is just a *scanned photo* of a leaflet contains no text or shapes to read, only pixels.
+- Check quickly: open the PDF and try to select a day number with the mouse. If the text highlights, it's a vector PDF and the parser should handle it; if nothing selects, it's a scan.
+- For scans and phone photos, set `anthropic_api_key` in the add-on configuration to enable the fallback (see [Importing the municipal schedule](#importing-the-municipal-schedule)), or add the dates by hand — the recurrence rules mean a typical schedule is two or three rules, not fifty dates.
+- The parser also needs the calendar rows to be labelled with **ISO week numbers** (`1.`, `2.`, …) and the columns with weekday abbreviations, which is how these leaflets are almost always laid out. A calendar without week numbers won't be recognised.
+
+**Schedule import found the days but the colours map to the wrong waste type**
+- The suggested type is only a guess from the colour — every municipality uses its own palette. Change the type in the dropdown next to each series before adding it; the suggestion is never applied without your confirmation.
+- If one waste type appears split into two series, that is usually intentional: the leaflet is carrying two different rounds (e.g. fortnightly and monthly), or a coloured border marks an add-on day. Pick the aggregate series (listed first, "all days where this colour appears") if you want everything, or the specific fill/outline combination if you're on one of the variants.
+
 **Weather screen never appears / motion doesn't trigger it**
 - Confirm the Home Assistant automation actually fired: check **Settings → Automations → (your automation) → Traces**
 - Call `curl -X POST http://YOUR_HA_IP:8099/weather-mode/on` manually and then check `GET /weather` — if `active` becomes `true`, the add-on side is working and the issue is in the automation/motion sensor
@@ -601,6 +611,9 @@ EXIF metadata is read from the JPG files. GPS coordinates are reverse-geocoded v
 - The web interface has **no authentication by default** – it is intended for use on a trusted local network. Enable `basic_auth_user` / `basic_auth_password` if you expose it externally.
 - The `/weather-mode/*` and `/weather-update` endpoints have no authentication beyond whatever `basic_auth_user`/`basic_auth_password` you've set — if you enable Basic Auth, remember to add the credentials to your `rest_command` definitions too (`headers: {Authorization: "Basic ..."}`).
 - SnapFrame never calls out to the Home Assistant API and needs no `homeassistant_api`/`hassio_api` permission or long-lived token — all HA integration is one-directional (HA → SnapFrame) via plain REST calls you configure yourself.
+- **Only one feature can send data off your network, and it is off by default.** With `anthropic_api_key` set, the schedule import falls back to sending the *uploaded schedule file* to Anthropic's API when the local PDF parser can't read it — see [Importing the municipal schedule](#importing-the-municipal-schedule). Nothing else in SnapFrame makes outbound calls except the optional Nominatim reverse-geocoding lookup for the photo location overlay. Your photos are never sent anywhere. Leave `anthropic_api_key` empty and SnapFrame stays entirely on your LAN; the PDF parser itself needs no key and no internet.
+- SnapFrame itself never stores an uploaded schedule: it is read, parsed, and dropped, and only the dates you confirm are saved (into `/data/waste_schedule.json`). Note that uploads larger than ~500 KB are buffered by the web server into a temporary file inside the container while the request is being handled; that file is removed as soon as the request finishes and never leaves the container.
+- `POST /waste/import` and `POST /waste/config` are protected only by whatever `basic_auth_user`/`basic_auth_password` you've set, like every other endpoint. Uploads are capped at 12 MB and the saved schedule is validated and clamped server-side (rule count, date count, value ranges), so a malformed or hostile request can't grow the stored config without bound.
 - The geocoding cache (`/data/geocode_cache.json`) stores GPS coordinates rounded to 2 decimal places (~1 km precision). It does not contain any other personal data.
 
 ---

--- a/snapframe/README.md
+++ b/snapframe/README.md
@@ -16,6 +16,7 @@ If you have a retired iPad, an old Android tablet, or any spare touchscreen gath
 - 📅 **EXIF overlay** – date and GPS location (via Nominatim reverse geocoding) shown on each photo
 - ⬆️ **Web upload** – upload photos directly from a phone's browser without needing SMB access; supports multiple files and creating new albums on the fly
 - 🌤️ **Motion-triggered weather screen** – trigger "weather mode" from a Home Assistant motion sensor (e.g. in the morning) so the slideshow inserts a nicely designed current-weather + today's forecast screen every few photos
+- 🗑️ **Waste collection reminders** – set up your municipal collection calendar in the app (every other Thursday, first Monday of the month, or plain dates) and the frame reminds you the day before which bin goes out — as a corner badge on the photos, a full-screen reminder every few photos, or both
 - 🌙 **Night mode** – configurable sleep schedule blanks the screen (plain black or an animated starry sky) to save your display and avoid a glowing photo frame at 3am
 - 🌍 **Multi-language UI** – Slovak, English, and German out of the box
 - ⚙️ **In-app settings** – night-mode theme can be changed directly from the slideshow, no need to touch the Home Assistant add-on configuration
@@ -23,7 +24,7 @@ If you have a retired iPad, an old Android tablet, or any spare touchscreen gath
 - 🗑️ **Trash** – long-press any photo to move it to `_kos/` subfolder (recoverable via SMB)
 - 👆 **Swipe gestures** – left/right to navigate, swipe down to return to album selection
 - 🔐 **Optional HTTP Basic Auth** – password-protect the web interface
-- 📡 **REST API** – `/status`, `/scan`, `/upload`, `/weather-mode/*` endpoints for Home Assistant automations
+- 📡 **REST API** – `/status`, `/scan`, `/upload`, `/weather-mode/*`, `/waste/*` endpoints for Home Assistant automations
 
 > Looking for keywords: *Home Assistant photo frame*, *digital picture frame add-on*, *HEIC to JPG converter for Home Assistant*, *iPad photo frame without iCloud*, *self-hosted Aura/Skylight/Nixplay alternative*, *old tablet recycle project*, *smart mirror weather display*. If that's what brought you here — you're in the right place.
 
@@ -198,7 +199,10 @@ Open `http://YOUR_HA_IP:8099` on your tablet/iPad (or any browser).
 
 ### Settings (⚙)
 
-Tap the gear icon in the top-right corner of the album selection screen to open in-app settings. Currently this lets you switch the night-mode screen between a plain black background and an animated starry sky with occasional shooting stars — saved per device via `localStorage`, no restart required.
+Tap the gear icon in the top-right corner of the album selection screen to open in-app settings:
+
+- **Night mode screen** – switch between a plain black background and an animated starry sky with occasional shooting stars. Saved per device via `localStorage`, no restart required.
+- **Waste collection…** – opens the waste collection calendar editor (see [Waste collection reminders](#waste-collection-reminders)). Unlike the night-mode theme this is stored on the server, so every tablet pointed at the add-on shares one schedule.
 
 ### Night mode
 
@@ -218,6 +222,110 @@ At the bottom of the album selection screen, tap **"↑ Upload photos"** to expa
 ### Manual scan
 
 Tap **"↻ Scan now"** on the album selection screen to trigger an immediate scan of the `watch_folder` without waiting for the next scheduled interval.
+
+---
+
+## Waste collection reminders
+
+The frame can remind you which bin goes out tomorrow, so the container actually makes it to the kerb the evening before.
+
+Everything is configured **in the app** — open the slideshow, tap the ⚙ gear on the album selection screen, then **"Waste collection…"**. Nothing here lives in the add-on options: a year of collection dates is miserable to maintain as YAML, and changing it would need an add-on restart. The schedule is stored in `/data/waste_schedule.json` (survives restarts and add-on updates) and is shared by every tablet pointed at this add-on.
+
+### Setting up a collection
+
+Tap **"+ Add collection"** and describe how that pickup repeats. Municipal calendars are almost never a flat list of dates, so there are three kinds of rule:
+
+| Repeats | Use it for | You configure |
+|---|---|---|
+| **Every N weeks** | *"mixed waste, every other Thursday"* | weekday, N (1–12), and a **reference date** — one real collection day, which fixes *which* week is the right one |
+| **Monthly** | *"paper, first Monday of the month"*, *"glass, on the 15th"* | position in the month (first…fifth or **last**) + weekday, **or** a day number; optionally restricted to certain months |
+| **Specific dates** | irregular pickups, bulky waste days | a list of dates you add one by one |
+
+Each rule additionally supports:
+
+- **Valid from / until** – e.g. a bio-waste rule that only runs April–November
+- **Exceptions** – single dates when the collection is cancelled (public holidays)
+- **Extra one-off dates** – a replacement pickup moved to a different day; these apply even outside the validity range
+- **Custom name** – overrides the built-in waste-type label (e.g. *"Yellow bags"* instead of *"Plastic"*)
+
+Ten waste types are built in (mixed, bio, plastic, paper, glass, metal, drink cartons, e-waste, bulky, other), each with its own icon and colour. Two collections falling on the same day are merged into one reminder.
+
+> **The reference date matters.** For *"every other Thursday"* the frame has no way to know which Thursday is yours — pick any single date you know there was (or will be) a collection, and the rest of the year follows from it. If you enter a date that isn't the chosen weekday it's snapped back to the nearest one, and the phase works in both directions, so a date in the future is fine too.
+
+### How the reminder appears
+
+Under **"How to show the reminder"**:
+
+- **Corner badge** – a small, high-contrast badge in the top-left corner of the photos, visible the whole time the reminder is active
+- **Full screen** – a full-screen reminder inserted between photos every *N* photos (default 10), like the weather screen
+- **Both**
+
+And under the timing options:
+
+- **Remind days ahead** (0–7, default 1) – how far in advance to warn. `1` is the useful one: the reminder appears all day the day before.
+- **Also remind on collection day** (default on) – keeps the reminder up on the morning of the collection itself. When a collection falls both today and tomorrow, today's wins.
+- **Show the reminder only from** (default 00:00) – suppresses the *day-before* reminder until that hour, so you're not looking at "tomorrow: plastic" from 6 a.m. The reminder on the collection day itself ignores this.
+
+The reminder is hidden while the weather screen is showing, during night mode, and outside the slideshow.
+
+> **Time zones:** the add-on only ships the *list of upcoming collection days*; the tablet's browser decides what "today" and "tomorrow" mean using its own local time. A container running in UTC therefore can't shift your reminder by a day.
+
+### Using the schedule in Home Assistant
+
+`GET /waste/next` is shaped for a REST sensor, so the same calendar can also drive a phone notification:
+
+```yaml
+# configuration.yaml
+sensor:
+  - platform: rest
+    name: Waste collection next
+    resource: http://homeassistant.local:8099/waste/next
+    value_template: "{{ value_json.state }}"      # next collection date, YYYY-MM-DD
+    json_attributes:
+      - days_until
+      - text                                       # "Plastic, Paper"
+      - types
+    scan_interval: 3600
+```
+
+```yaml
+# automation: nudge my phone at 6 p.m. the day before
+automation:
+  - alias: "Waste collection tomorrow"
+    triggers:
+      - trigger: time
+        at: "18:00:00"
+    conditions:
+      - condition: template
+        value_template: >
+          {{ state_attr('sensor.waste_collection_next', 'days_until') | int(-1) == 1 }}
+    actions:
+      - action: notify.mobile_app_my_phone
+        data:
+          title: "Bin out tonight"
+          message: >
+            Tomorrow: {{ state_attr('sensor.waste_collection_next', 'text') }}
+```
+
+If the web interface is protected with `basic_auth_user` / `basic_auth_password`, add `username` / `password` to the REST sensor.
+
+### `/waste/next` response example
+
+```json
+{
+  "ok": true,
+  "state": "2026-08-27",
+  "date": "2026-08-27",
+  "days_until": 1,
+  "text": "Plastic, Paper",
+  "types": [
+    { "id": "plastic", "label": "Plastic", "icon": "\ud83e\udd64", "color": "#f2c200" },
+    { "id": "paper",   "label": "Paper",   "icon": "\ud83d\udcc4", "color": "#4a90e2" }
+  ]
+}
+```
+
+When nothing is scheduled, `state` is an empty string and `days_until` is `null`.
 
 ---
 
@@ -329,6 +437,10 @@ To turn weather mode off early (e.g. from another automation, or a script tied t
 | `POST` | `/weather-mode/off` | Deactivate weather mode immediately |
 | `POST` | `/weather-update` | Push current weather data (JSON body, see [Weather mode](#weather-mode-motion-triggered-morning-briefing)) |
 | `GET` | `/weather` | JSON with weather-mode status and the last pushed weather data |
+| `GET` | `/waste/config` | Full waste calendar config + the waste-type catalogue (used by the in-app editor) |
+| `POST` | `/waste/config` | Replace the waste calendar config (JSON body; validated and clamped server-side) |
+| `GET` | `/waste/status` | Display settings + expanded collection days for the next ~3 weeks |
+| `GET` | `/waste/next` | Next collection — shaped for a Home Assistant REST sensor |
 
 ### `/status` response example
 

--- a/snapframe/config.yaml
+++ b/snapframe/config.yaml
@@ -1,5 +1,5 @@
 name: "SnapFrame – Digital Photo Frame"
-version: "2.10.0"
+version: "2.11.0"
 slug: "snapframe"
 description: "Turn any old tablet or iPad into a smart digital photo frame. Watches an SMB share, converts HEIC/HEIF to JPG, and serves a fullscreen slideshow with albums, EXIF date/GPS overlay, swipe gestures, web upload, night mode, a motion-triggered weather screen and waste-collection reminders."
 url: "https://github.com/emo546/ha-snapframe"
@@ -31,6 +31,7 @@ options:
   sleep_end: ""
   weather_photo_interval: 8
   weather_mode_duration_minutes: 120
+  anthropic_api_key: ""
 schema:
   smb_server: str
   smb_share: str
@@ -52,6 +53,7 @@ schema:
   sleep_end: str
   weather_photo_interval: int(2,50)
   weather_mode_duration_minutes: int(5,720)
+  anthropic_api_key: "password?"
 ports:
   8099/tcp: 8099
 ports_description:

--- a/snapframe/config.yaml
+++ b/snapframe/config.yaml
@@ -1,7 +1,7 @@
 name: "SnapFrame – Digital Photo Frame"
-version: "2.9.1"
+version: "2.10.0"
 slug: "snapframe"
-description: "Turn any old tablet or iPad into a smart digital photo frame. Watches an SMB share, converts HEIC/HEIF to JPG, and serves a fullscreen slideshow with albums, EXIF date/GPS overlay, swipe gestures, web upload, night mode and a motion-triggered weather screen."
+description: "Turn any old tablet or iPad into a smart digital photo frame. Watches an SMB share, converts HEIC/HEIF to JPG, and serves a fullscreen slideshow with albums, EXIF date/GPS overlay, swipe gestures, web upload, night mode, a motion-triggered weather screen and waste-collection reminders."
 url: "https://github.com/emo546/ha-snapframe"
 arch:
   - aarch64

--- a/snapframe/rootfs/usr/bin/run.sh
+++ b/snapframe/rootfs/usr/bin/run.sh
@@ -20,6 +20,7 @@ SLEEP_START=$(bashio::config 'sleep_start')
 SLEEP_END=$(bashio::config 'sleep_end')
 WEATHER_PHOTO_INTERVAL=$(bashio::config 'weather_photo_interval')
 WEATHER_MODE_DURATION_MIN=$(bashio::config 'weather_mode_duration_minutes')
+ANTHROPIC_API_KEY=$(bashio::config 'anthropic_api_key')
 
 # bashio vracia "null" pre nové polia ktoré ešte nie sú v options – nahraď defaultmi
 [ "${THUMB_QUALITY}" = "null" ]      && THUMB_QUALITY="82"
@@ -31,6 +32,7 @@ WEATHER_MODE_DURATION_MIN=$(bashio::config 'weather_mode_duration_minutes')
 [ "${SLEEP_END}" = "null" ]           && SLEEP_END=""
 [ "${WEATHER_PHOTO_INTERVAL}" = "null" ]    && WEATHER_PHOTO_INTERVAL="8"
 [ "${WEATHER_MODE_DURATION_MIN}" = "null" ] && WEATHER_MODE_DURATION_MIN="120"
+[ "${ANTHROPIC_API_KEY}" = "null" ]           && ANTHROPIC_API_KEY=""
 
 bashio::log.info "SMB server: ${SMB_SERVER}"
 bashio::log.info "SMB share: ${SMB_SHARE}"
@@ -89,6 +91,7 @@ export SLEEP_START
 export SLEEP_END
 export WEATHER_PHOTO_INTERVAL
 export WEATHER_MODE_DURATION_MIN
+export ANTHROPIC_API_KEY
 export PYTHONPATH="/usr/bin:${PYTHONPATH:-}"
 
 bashio::log.info "Slideshow interval: ${SLIDESHOW_SECONDS} s"

--- a/snapframe/rootfs/usr/bin/waste.py
+++ b/snapframe/rootfs/usr/bin/waste.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""
+SnapFrame – kalendár vývozu odpadu (waste collection calendar).
+
+Model:
+  * Konfigurácia je jeden JSON súbor v /data (prežije reštart aj update add-onu),
+    editovateľný priamo z webového rozhrania – žiadne prepisovanie YAML options
+    kvôli desiatkam dátumov.
+  * Kalendár nie je zoznam dátumov, ale zoznam PRAVIDIEL (rules). Reálne obecné
+    harmonogramy sú takmer vždy "každý druhý štvrtok" alebo "prvý pondelok
+    v mesiaci"; explicitné dátumy sú len tretia možnosť pre nepravidelné zvozy.
+    Ku každému pravidlu sa dá pridať platnosť od/do, výnimky (skip) a
+    mimoriadne termíny navyše (extra).
+  * Modul počíta LEN výskyty (occurrences) pre dané okno dní. Rozhodnutie
+    "čo sa vyváža zajtra" robí prehliadač na tablete – ten má na rozdiel od
+    kontajnera vždy správnu lokálnu časovú zónu.
+"""
+
+import json
+import logging
+import os
+import re
+import threading
+from collections import OrderedDict
+from datetime import date, timedelta
+
+log = logging.getLogger("snapframe.waste")
+
+CONFIG_FILE = os.environ.get("WASTE_CONFIG_FILE", "/data/waste_schedule.json")
+
+MAX_RULES     = 40      # ochrana proti nezmyselne veľkému configu z prehliadača
+MAX_DATES     = 400     # max. dátumov v jednom zozname (dates / skip / extra)
+UPCOMING_DAYS = 24      # koľko dní dopredu posielame do prehliadača
+
+_lock = threading.Lock()
+
+# ── Katalóg druhov odpadu ────────────────────────────────────────────────────
+# icon = emoji (žiadne externé assety, funguje aj na starom iPad Safari)
+# color = farba pruhu/akcentu v UI
+WASTE_TYPES = OrderedDict([
+    ("mixed",    {"icon": "\U0001F5D1️", "color": "#8b95a5",
+                  "labels": {"sk": "Zmesový odpad", "en": "Mixed waste",     "de": "Restmüll"}}),
+    ("bio",      {"icon": "\U0001F33F",       "color": "#7cb342",
+                  "labels": {"sk": "Bioodpad",      "en": "Bio waste",       "de": "Biomüll"}}),
+    ("plastic",  {"icon": "\U0001F964",       "color": "#f2c200",
+                  "labels": {"sk": "Plasty",        "en": "Plastic",         "de": "Kunststoff"}}),
+    ("paper",    {"icon": "\U0001F4C4",       "color": "#4a90e2",
+                  "labels": {"sk": "Papier",        "en": "Paper",           "de": "Papier"}}),
+    ("glass",    {"icon": "\U0001F37E",       "color": "#26a96c",
+                  "labels": {"sk": "Sklo",          "en": "Glass",           "de": "Glas"}}),
+    ("metal",    {"icon": "\U0001F96B",       "color": "#e0574f",
+                  "labels": {"sk": "Kovy",          "en": "Metal",           "de": "Metall"}}),
+    ("tetrapak", {"icon": "\U0001F9C3",       "color": "#ff8a3d",
+                  "labels": {"sk": "Tetrapak (VKM)", "en": "Drink cartons",  "de": "Getränkekartons"}}),
+    ("electro",  {"icon": "\U0001F50C",       "color": "#a855f7",
+                  "labels": {"sk": "Elektroodpad",  "en": "E-waste",         "de": "Elektroschrott"}}),
+    ("bulky",    {"icon": "\U0001F6CB️", "color": "#a9805e",
+                  "labels": {"sk": "Objemný odpad", "en": "Bulky waste",     "de": "Sperrmüll"}}),
+    ("other",    {"icon": "♻️",     "color": "#9aa5b1",
+                  "labels": {"sk": "Iný odpad",     "en": "Other waste",     "de": "Sonstiger Abfall"}}),
+])
+
+DEFAULT_CONFIG = {
+    "enabled":        False,
+    "mode":           "overlay",   # overlay | slide | both
+    "photo_interval": 10,          # po koľkých fotkách vložiť celoobrazovkový slide
+    "days_before":    1,           # koľko dní vopred upozorniť
+    "show_on_day":    True,        # upozorniť aj ráno v deň vývozu
+    "start_hour":     0,           # deň-vopred upozornenie zobrazovať až od tejto hodiny
+    "rules":          [],
+}
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+# ── Malé helpery ─────────────────────────────────────────────────────────────
+
+def _clamp_int(value, lo, hi, default):
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return lo if n < lo else (hi if n > hi else n)
+
+
+def _parse_date(value):
+    """'YYYY-MM-DD' -> date, inak None."""
+    s = str(value or "").strip()
+    if not _DATE_RE.match(s):
+        return None
+    try:
+        y, m, d = s.split("-")
+        return date(int(y), int(m), int(d))
+    except ValueError:
+        return None
+
+
+def _valid_date_str(value):
+    d = _parse_date(value)
+    return d.isoformat() if d else ""
+
+
+def _clean_dates(value):
+    """Zoznam dátumových reťazcov -> zoradený zoznam validných unikátnych ISO dátumov."""
+    if not isinstance(value, (list, tuple)):
+        return []
+    seen = set()
+    for item in value[:MAX_DATES * 2]:
+        iso = _valid_date_str(item)
+        if iso:
+            seen.add(iso)
+    return sorted(seen)[:MAX_DATES]
+
+
+def _clean_months(value):
+    """Zoznam čísel mesiacov 1–12; prázdny zoznam = bez obmedzenia."""
+    if not isinstance(value, (list, tuple)):
+        return []
+    out = set()
+    for item in value[:12]:
+        try:
+            n = int(item)
+        except (TypeError, ValueError):
+            continue
+        if 1 <= n <= 12:
+            out.add(n)
+    return sorted(out)
+
+
+def _rule_id(value):
+    s = re.sub(r"[^A-Za-z0-9_-]", "", str(value or ""))[:24]
+    return s or "r{}".format(os.urandom(4).hex())
+
+
+def _nth_weekday(year, month, weekday, nth):
+    """N-tý daný deň v týždni v mesiaci. nth: 1..5, alebo -1 = posledný."""
+    if nth < 0:
+        first_next = date(year + 1, 1, 1) if month == 12 else date(year, month + 1, 1)
+        last = first_next - timedelta(days=1)
+        return last - timedelta(days=(last.weekday() - weekday) % 7)
+    first  = date(year, month, 1)
+    day    = 1 + ((weekday - first.weekday()) % 7) + (nth - 1) * 7
+    try:
+        return date(year, month, day)
+    except ValueError:
+        return None   # napr. 5. pondelok v mesiaci, ktorý ho nemá
+
+
+# ── Sanitizácia configu (dáta prichádzajú z prehliadača) ─────────────────────
+
+def _sanitize_rule(raw):
+    if not isinstance(raw, dict):
+        return None
+    rtype = str(raw.get("type") or "").strip()
+    if rtype not in WASTE_TYPES:
+        rtype = "other"
+
+    raw_rec = raw.get("recurrence")
+    if not isinstance(raw_rec, dict):
+        raw_rec = {}
+    kind = str(raw_rec.get("kind") or "dates")
+    if kind not in ("dates", "weekly", "monthly"):
+        kind = "dates"
+
+    rec = {"kind": kind}
+    extra = _clean_dates(raw.get("extra"))
+    if kind == "dates":
+        rec["dates"] = _clean_dates(raw_rec.get("dates"))
+        if not rec["dates"] and not extra:
+            return None                       # pravidlo bez jediného termínu
+    elif kind == "weekly":
+        rec["weekday"]        = _clamp_int(raw_rec.get("weekday"), 0, 6, 0)
+        rec["interval_weeks"] = _clamp_int(raw_rec.get("interval_weeks"), 1, 12, 1)
+        rec["anchor"]         = _valid_date_str(raw_rec.get("anchor"))
+        rec["months"]         = _clean_months(raw_rec.get("months"))
+        if rec["interval_weeks"] > 1 and not rec["anchor"]:
+            # bez kotvy sa nedá určiť fáza „každý druhý týždeň“
+            rec["interval_weeks"] = 1
+    else:
+        by = str(raw_rec.get("monthly_by") or "weekday")
+        rec["monthly_by"]    = by if by in ("weekday", "day") else "weekday"
+        rec["weekday"]       = _clamp_int(raw_rec.get("weekday"), 0, 6, 0)
+        wom                  = _clamp_int(raw_rec.get("week_of_month"), -1, 5, 1)
+        rec["week_of_month"] = 1 if wom == 0 else wom
+        rec["day_of_month"]  = _clamp_int(raw_rec.get("day_of_month"), 1, 31, 1)
+        rec["months"]        = _clean_months(raw_rec.get("months"))
+
+    return {
+        "id":         _rule_id(raw.get("id")),
+        "type":       rtype,
+        "label":      str(raw.get("label") or "").strip()[:40],
+        "recurrence": rec,
+        "from":       _valid_date_str(raw.get("from")),
+        "to":         _valid_date_str(raw.get("to")),
+        "skip":       _clean_dates(raw.get("skip")),
+        "extra":      extra,
+    }
+
+
+def sanitize_config(raw):
+    if not isinstance(raw, dict):
+        raw = {}
+    mode = str(raw.get("mode") or "overlay")
+    cfg = {
+        "enabled":        bool(raw.get("enabled", False)),
+        "mode":           mode if mode in ("overlay", "slide", "both") else "overlay",
+        "photo_interval": _clamp_int(raw.get("photo_interval"), 2, 100, 10),
+        "days_before":    _clamp_int(raw.get("days_before"), 0, 7, 1),
+        "show_on_day":    bool(raw.get("show_on_day", True)),
+        "start_hour":     _clamp_int(raw.get("start_hour"), 0, 23, 0),
+        "rules":          [],
+    }
+    if cfg["days_before"] == 0:
+        cfg["show_on_day"] = True     # inak by sa neukázalo nikdy nič
+    rules = raw.get("rules")
+    if isinstance(rules, list):
+        used_ids = set()
+        for item in rules[:MAX_RULES]:
+            rule = _sanitize_rule(item)
+            if not rule:
+                continue
+            while rule["id"] in used_ids:
+                rule["id"] = _rule_id(None)
+            used_ids.add(rule["id"])
+            cfg["rules"].append(rule)
+    return cfg
+
+
+# ── Načítanie / uloženie ─────────────────────────────────────────────────────
+
+def load_config():
+    with _lock:
+        try:
+            with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+                raw = json.load(f)
+        except FileNotFoundError:
+            return sanitize_config(DEFAULT_CONFIG)
+        except Exception as e:
+            log.warning("Kalendár odpadu – načítanie zlyhalo: {}".format(e))
+            return sanitize_config(DEFAULT_CONFIG)
+    return sanitize_config(raw)
+
+
+def save_config(raw):
+    """Zvaliduje a atomicky uloží konfiguráciu. Vracia uloženú (očistenú) verziu."""
+    cfg = sanitize_config(raw)
+    with _lock:
+        tmp = CONFIG_FILE + ".tmp"
+        try:
+            os.makedirs(os.path.dirname(CONFIG_FILE) or ".", exist_ok=True)
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(cfg, f, ensure_ascii=False, indent=2)
+            os.replace(tmp, CONFIG_FILE)
+        except Exception as e:
+            log.error("Kalendár odpadu – uloženie zlyhalo: {}".format(e))
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+            raise
+    return cfg
+
+
+# ── Výpočet výskytov ─────────────────────────────────────────────────────────
+
+def _compile_rule(rule):
+    """Predparsuje dátumové reťazce, aby sa to nerobilo pre každý deň znova."""
+    rec = rule.get("recurrence") or {}
+    compiled = {
+        "type":  rule.get("type", "other"),
+        "label": rule.get("label", ""),
+        "kind":  rec.get("kind", "dates"),
+        "from":  _parse_date(rule.get("from")),
+        "to":    _parse_date(rule.get("to")),
+        "skip":  set(rule.get("skip") or []),
+        "extra": set(rule.get("extra") or []),
+        "rec":   rec,
+        "dates": set(rec.get("dates") or []),
+    }
+    anchor = _parse_date(rec.get("anchor"))
+    if anchor is not None and rec.get("kind") == "weekly":
+        # kotvu zarovnaj na požadovaný deň v týždni, nech fáza sedí aj keď
+        # používateľ zadá dátum, ktorý na daný deň nepadne
+        weekday = _clamp_int(rec.get("weekday"), 0, 6, anchor.weekday())
+        anchor -= timedelta(days=(anchor.weekday() - weekday) % 7)
+    compiled["anchor"] = anchor
+    return compiled
+
+
+def _matches(c, day):
+    iso = day.isoformat()
+    if iso in c["skip"]:
+        return False
+    if iso in c["extra"]:
+        return True
+    if c["from"] and day < c["from"]:
+        return False
+    if c["to"] and day > c["to"]:
+        return False
+
+    rec  = c["rec"]
+    kind = c["kind"]
+    if kind == "dates":
+        return iso in c["dates"]
+
+    months = rec.get("months") or []
+    if months and day.month not in months:
+        return False
+
+    if kind == "weekly":
+        if day.weekday() != _clamp_int(rec.get("weekday"), 0, 6, 0):
+            return False
+        every = _clamp_int(rec.get("interval_weeks"), 1, 12, 1)
+        if every <= 1:
+            return True
+        if c["anchor"] is None:
+            return True
+        return (((day - c["anchor"]).days // 7) % every) == 0
+
+    if kind == "monthly":
+        if rec.get("monthly_by") == "day":
+            return day.day == _clamp_int(rec.get("day_of_month"), 1, 31, 1)
+        target = _nth_weekday(day.year, day.month,
+                              _clamp_int(rec.get("weekday"), 0, 6, 0),
+                              _clamp_int(rec.get("week_of_month"), -1, 5, 1))
+        return target is not None and target == day
+
+    return False
+
+
+def type_info(type_id, lang="sk", custom_label=""):
+    meta = WASTE_TYPES.get(type_id) or WASTE_TYPES["other"]
+    labels = meta["labels"]
+    return {
+        "id":    type_id if type_id in WASTE_TYPES else "other",
+        "label": custom_label or labels.get(lang) or labels["en"],
+        "icon":  meta["icon"],
+        "color": meta["color"],
+    }
+
+
+def type_catalog(lang="sk"):
+    return [type_info(tid, lang) for tid in WASTE_TYPES]
+
+
+def occurrences(cfg, start, days=UPCOMING_DAYS, lang="sk"):
+    """Zoznam dní (od `start`, `days` dopredu), v ktorých sa niečo vyváža."""
+    compiled = [_compile_rule(r) for r in (cfg.get("rules") or [])]
+    out = []
+    for offset in range(max(0, days)):
+        day   = start + timedelta(days=offset)
+        types = []
+        seen  = set()
+        for c in compiled:
+            if not _matches(c, day):
+                continue
+            info = type_info(c["type"], lang, c["label"])
+            key  = (info["id"], info["label"])
+            if key in seen:
+                continue
+            seen.add(key)
+            types.append(info)
+        if types:
+            out.append({"date": day.isoformat(), "types": types})
+    return out
+
+
+def next_collection(cfg, today=None, lang="sk", horizon=400):
+    """Najbližší vývoz od dneška (vrátane) – pre REST senzor v Home Assistante."""
+    today = today or date.today()
+    found = occurrences(cfg, today, horizon, lang)
+    if not found:
+        return None
+    entry = found[0]
+    day   = _parse_date(entry["date"]) or today
+    entry = dict(entry)
+    entry["days_until"] = (day - today).days
+    return entry

--- a/snapframe/rootfs/usr/bin/waste_import.py
+++ b/snapframe/rootfs/usr/bin/waste_import.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""
+SnapFrame – import zvozového harmonogramu z PDF (prípadne z obrázka).
+
+Prečo geometria a nie OCR:
+    Obecné harmonogramy sú mriežkový kalendár, kde nesie význam FARBA bunky,
+    nie text – v texte sú len čísla dní. OCR by vrátilo čísla bez informácie,
+    ktoré z nich sú vývozy. Vektorové PDF má ale aj čísla, aj farebné
+    obdĺžniky so súradnicami, takže sa dajú spárovať priamo a presne –
+    bez OCR, bez siete, bez API kľúča.
+
+Ako sa určuje dátum:
+    Riadky sú očíslované číslom ISO týždňa a stĺpce sú dni v týždni, takže
+    (ISO týždeň + deň v týždni) dá presný dátum. Vytlačené číslo dňa sa potom
+    použije ako kontrola – ak nesedí, bunka sa zahodí. Nemusíme teda vôbec
+    riešiť, ktorý blok na stránke je ktorý mesiac.
+
+Čo sa vracia:
+    Zoznam "radov" (series) = skupín dní s rovnakým farebným kódom, nie hotové
+    druhy odpadu. Paleta sa zámerne nehardcoduje: jedna obec má plasty žlté,
+    iná modré, a ten istý leták môže obsahovať dva rôzne harmonogramy naraz
+    (napr. dvojtýždňový aj mesačný zvoz zmesového odpadu) – ktorý z nich sa
+    týka konkrétnej domácnosti, vie iba používateľ. Priradenie radu k druhu
+    odpadu preto robí človek v appke; my ponúkneme len návrh podľa farby.
+"""
+
+import base64
+import io
+import json
+import logging
+import os
+import re
+from collections import Counter, defaultdict
+from datetime import date
+
+log = logging.getLogger("snapframe.waste_import")
+
+MAX_UPLOAD_BYTES = 12 * 1024 * 1024
+MIN_MAPPED_DAYS  = 40      # pod touto hranicou parser vyhlási neúspech
+MAX_SERIES       = 24
+MAX_DATES        = 400
+
+# Skratky dní v týždni, ktoré vieme rozpoznať v hlavičke tabuľky.
+WEEKDAY_HEADERS = {
+    "po": 0, "mo": 0, "mon": 0, "pon": 0,
+    "ut": 1, "tu": 1, "tue": 1, "di": 1, "út": 1,
+    "st": 2, "we": 2, "wed": 2, "mi": 2,
+    "št": 3, "st.": 3, "th": 3, "thu": 3, "do": 3, "čt": 3,
+    "pi": 4, "fr": 4, "fri": 4, "pá": 4,
+    "so": 5, "sa": 5, "sat": 5,
+    "ne": 6, "su": 6, "sun": 6, "so.": 6,
+}
+
+# Návrh druhu odpadu podľa farby výplne. Len návrh – používateľ ho prepíše.
+COLOUR_HINTS = [
+    ((0.00, 0.00, 0.00), "mixed",    "čierna"),
+    ((0.35, 0.35, 0.35), "mixed",    "sivá"),
+    ((0.45, 0.75, 0.30), "mixed",    "zelená"),
+    ((0.00, 0.55, 0.25), "glass",    "tmavozelená"),
+    ((0.80, 0.40, 0.10), "bio",      "hnedá"),
+    ((0.55, 0.27, 0.07), "bio",      "tmavohnedá"),
+    ((1.00, 1.00, 0.00), "plastic",  "žltá"),
+    ((1.00, 0.75, 0.00), "plastic",  "oranžovožltá"),
+    ((0.00, 0.69, 0.94), "paper",    "modrá"),
+    ((0.00, 0.44, 0.75), "paper",    "tmavomodrá"),
+    ((1.00, 0.00, 0.00), "metal",    "červená"),
+    ((0.60, 0.30, 0.70), "electro",  "fialová"),
+]
+
+
+# ── Farby ────────────────────────────────────────────────────────────────────
+
+def _norm_colour(c):
+    """PDF farbu (grayscale float / 1-, 3- alebo 4-zložkovú) sprav na RGB 0–1."""
+    if c is None:
+        return None
+    if isinstance(c, (int, float)):
+        v = float(c)
+        return (v, v, v)
+    if isinstance(c, (list, tuple)):
+        try:
+            vals = [float(x) for x in c]
+        except (TypeError, ValueError):
+            return None
+        if len(vals) == 1:
+            return (vals[0],) * 3
+        if len(vals) == 3:
+            return tuple(vals)
+        if len(vals) == 4:                      # CMYK
+            cy, m, y, k = vals
+            return (max(0.0, 1 - min(1, cy + k)),
+                    max(0.0, 1 - min(1, m + k)),
+                    max(0.0, 1 - min(1, y + k)))
+    return None
+
+
+def _hex(rgb):
+    return "#{:02x}{:02x}{:02x}".format(
+        *[max(0, min(255, int(round(v * 255)))) for v in rgb])
+
+
+def _is_background(rgb):
+    """Biela a svetlá sivá sú mriežka/pozadie, nie značka vývozu."""
+    r, g, b = rgb
+    return min(r, g, b) > 0.80 and (max(r, g, b) - min(r, g, b)) < 0.06
+
+
+def _colour_hint(rgb):
+    best, best_d = ("other", ""), 9.0
+    for ref, type_id, name in COLOUR_HINTS:
+        d = sum((a - b) ** 2 for a, b in zip(ref, rgb))
+        if d < best_d:
+            best, best_d = (type_id, name), d
+    return best if best_d < 0.25 else ("other", "")
+
+
+# ── Popis pravidelnosti radu ─────────────────────────────────────────────────
+
+WEEKDAY_NAMES = {
+    "sk": ["pondelok", "utorok", "streda", "štvrtok", "piatok", "sobota", "nedeľa"],
+    "en": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+    "de": ["Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag", "Sonntag"],
+}
+
+_FREQ = {
+    "sk": {7: "každý týždeň", 14: "každé 2 týždne", 21: "každé 3 týždne",
+           28: "každé 4 týždne", 0: "nepravidelne"},
+    "en": {7: "weekly", 14: "every 2 weeks", 21: "every 3 weeks",
+           28: "every 4 weeks", 0: "irregular"},
+    "de": {7: "wöchentlich", 14: "alle 2 Wochen", 21: "alle 3 Wochen",
+           28: "alle 4 Wochen", 0: "unregelmäßig"},
+}
+
+
+def _summarise(dates, lang="sk"):
+    """Ľudský popis radu, napr. 'každé 2 týždne · štvrtok'."""
+    if not dates:
+        return ""
+    names = WEEKDAY_NAMES.get(lang, WEEKDAY_NAMES["sk"])
+    freq  = _FREQ.get(lang, _FREQ["sk"])
+    parts = []
+    if len(dates) > 1:
+        gaps = Counter((dates[i + 1] - dates[i]).days for i in range(len(dates) - 1))
+        gap, hits = gaps.most_common(1)[0]
+        # za pravidelný rad považujeme ten, kde väčšina odstupov sedí
+        parts.append(freq.get(gap if hits >= len(dates) * 0.6 else 0, freq[0]))
+    wd = Counter(d.weekday() for d in dates)
+    if wd and wd.most_common(1)[0][1] >= len(dates) * 0.8:
+        parts.append(names[wd.most_common(1)[0][0]])
+    return " · ".join(p for p in parts if p)
+
+
+# ── Parsovanie PDF ───────────────────────────────────────────────────────────
+
+def _guess_year(text, today=None):
+    """Rok z hlavičky letáku; inak aktuálny (resp. nasledujúci od decembra)."""
+    today = today or date.today()
+    years = [int(y) for y in re.findall(r"\b(20\d{2})\b", text or "")]
+    plausible = [y for y in years if today.year - 1 <= y <= today.year + 2]
+    if plausible:
+        return Counter(plausible).most_common(1)[0][0]
+    return today.year + 1 if today.month == 12 else today.year
+
+
+def _cell_dates(page, year):
+    """Spáruj čísla dní s dátumami cez (ISO týždeň, deň v týždni)."""
+    words = page.extract_words()
+    cx = lambda w: (w["x0"] + w["x1"]) / 2.0        # noqa: E731
+    cy = lambda w: (w["top"] + w["bottom"]) / 2.0   # noqa: E731
+
+    headers, weeks, days = [], [], []
+    for w in words:
+        t = w["text"].strip()
+        key = t.lower().rstrip(".")
+        if key in WEEKDAY_HEADERS and len(t) <= 4:
+            headers.append((w, WEEKDAY_HEADERS[key]))
+        elif re.fullmatch(r"\d{1,2}\.", t):
+            weeks.append(w)
+        elif re.fullmatch(r"\d{1,2}", t):
+            days.append(w)
+    if not headers or not weeks:
+        return []
+
+    out = []
+    for n in days:
+        hdr, wd = min(headers, key=lambda h: abs(cx(h[0]) - cx(n)))
+        if abs(cx(hdr) - cx(n)) > 12:
+            continue
+        row = [w for w in weeks if abs(cy(w) - cy(n)) < 5 and w["x1"] < n["x0"]]
+        if not row:
+            continue
+        week = int(min(row, key=lambda w: cx(n) - cx(w))["text"].rstrip("."))
+        try:
+            d = date.fromisocalendar(year, week, wd + 1)
+        except ValueError:
+            continue
+        if d.day != int(n["text"]):     # kontrola proti vytlačenému číslu
+            continue
+        out.append((d, n))
+    return out
+
+
+def _grid_pitch(cells):
+    """Rozostup buniek mriežky (šírka stĺpca, výška riadka) priamo zo stránky.
+
+    Nedá sa použiť konštanta v bodoch: ten istý harmonogram vysádzaný na A4
+    a na A5 má iné rozstupy a natvrdo zadaný polomer by pri jednom z nich
+    priradil značku susednému dňu.
+    """
+    xs = sorted({round((w["x0"] + w["x1"]) / 2.0, 1) for _, w in cells})
+    ys = sorted({round((w["top"] + w["bottom"]) / 2.0, 1) for _, w in cells})
+
+    def pitch(vals, fallback):
+        gaps = [b - a for a, b in zip(vals, vals[1:]) if 3.0 < b - a < 80.0]
+        if not gaps:
+            return fallback
+        gaps.sort()
+        return gaps[len(gaps) // 2]                 # medián odolá odskokom medzi blokmi
+
+    return pitch(xs, 20.0), pitch(ys, 16.0)
+
+
+def _marks_by_date(page, cells):
+    """Ku každému dňu zisti farbu výplne bunky a farby prípadného rámika."""
+    cx = lambda w: (w["x0"] + w["x1"]) / 2.0        # noqa: E731
+    cy = lambda w: (w["top"] + w["bottom"]) / 2.0   # noqa: E731
+    cw, ch = _grid_pitch(cells)
+    fills   = {}
+    borders = defaultdict(set)
+    edges   = []
+
+    def nearest(pool, rx, ry, reach=0.85):
+        """Najbližší deň v mierke bunky; None, ak je značka mimo mriežky."""
+        if not pool:
+            return None
+        best = min(pool, key=lambda c: ((cx(c[1]) - rx) / cw) ** 2
+                                     + ((cy(c[1]) - ry) / ch) ** 2)
+        if abs(cx(best[1]) - rx) > cw * reach or abs(cy(best[1]) - ry) > ch * reach:
+            return None
+        return best
+
+    for r in page.rects:
+        rgb = _norm_colour(r.get("non_stroking_color"))
+        if rgb is None or _is_background(rgb):
+            continue
+        rx, ry = (r["x0"] + r["x1"]) / 2.0, (r["top"] + r["bottom"]) / 2.0
+        # Výplň bunky vyplní väčšinu jej plochy; čokoľvek tenšie je kus rámika.
+        if r["width"] > cw * 0.6 and r["height"] > ch * 0.6:
+            best = nearest(cells, rx, ry)
+            if best is not None:
+                fills[best[0]] = rgb
+        else:
+            edges.append((rx, ry, tuple(round(v, 3) for v in rgb)))
+
+    # Rámik sa kreslí PO obvode bunky, takže jeho segmenty ležia bližšie k
+    # susednému dňu než k tomu, ktorý zvýrazňujú. Priraď ich preto prednostne
+    # k vyfarbenej bunke – rámik zvýrazňuje označený deň, nie prázdny.
+    filled = [c for c in cells if c[0] in fills]
+    for rx, ry, rgb in edges:
+        best = nearest(filled, rx, ry, reach=1.15) or nearest(cells, rx, ry)
+        if best is None:
+            continue                                # legenda, nie kalendár
+        borders[best[0]].add(rgb)
+    return fills, borders
+
+
+def _build_series(fills, borders, lang):
+    """Zoskup dni do radov – a to na dvoch úrovniach naraz.
+
+    Rámik okolo bunky totiž neoznačuje iný odpad, ale podmnožinu alebo príplatok:
+    na tomto letáku je čierna bunka zvoz zmesového odpadu, pričom čierne bunky
+    so zeleným rámikom sú navyše termíny pre domácnosti s mesačnou frekvenciou,
+    a hnedý rámik na žltej bunke znamená "BIO aj plast v ten istý deň".
+    Preto ponúkame aj súhrn "všetky dni, kde sa daná farba vyskytuje" (fill aj
+    rámik), aj jednotlivé presné kombinácie – ktorá z nich platí pre konkrétnu
+    domácnosť, rozhodne používateľ v appke.
+    """
+    combos  = defaultdict(set)   # (výplň, rámik) -> dni
+    anycol  = defaultdict(set)   # farba -> dni, kde sa vyskytuje akokoľvek
+
+    for d, rgb in fills.items():
+        fill_key = tuple(round(v, 3) for v in rgb)
+        edge = sorted(c for c in borders.get(d, ()) if c != fill_key)
+        combos[(fill_key, tuple(edge[:1]))].add(d)
+        anycol[fill_key].add(d)
+        for c in edge:
+            anycol[c].add(d)
+    for d, edges in borders.items():
+        if d in fills:
+            continue
+        for e in edges:                 # deň označený iba rámikom
+            combos[(e, ())].add(d)
+            anycol[e].add(d)
+
+    candidates = []
+    for colour, dates in anycol.items():
+        candidates.append((colour, (), dates, True))
+    for (fill_key, edge), dates in combos.items():
+        candidates.append((fill_key, edge, dates, False))
+
+    series, seen = [], set()
+    for colour, edge, dates, is_aggregate in candidates:
+        dates = sorted(dates)[:MAX_DATES]
+        if len(dates) < 2:              # jediný výskyt = takmer isto legenda
+            continue
+        key = (colour, tuple(dates))
+        if key in seen:                 # súhrn je zhodný s kombináciou
+            continue
+        seen.add(key)
+        type_id, colour_name = _colour_hint(colour)
+        series.append({
+            "id":             "s{}".format(len(series) + 1),
+            "fill":           _hex(colour),
+            "outline":        _hex(edge[0]) if edge else "",
+            "colour_name":    colour_name,
+            "aggregate":      is_aggregate,
+            "suggested_type": type_id,
+            "dates":          [d.isoformat() for d in dates],
+            "count":          len(dates),
+            "summary":        _summarise(dates, lang),
+        })
+    # najprv súhrny (tie sedia väčšine domácností), v rámci nich najpočetnejšie
+    series.sort(key=lambda s: (not s["aggregate"], -s["count"]))
+    return series[:MAX_SERIES]
+
+
+def parse_pdf(data, lang="sk", today=None):
+    """Vytiahni rady vývozov z vektorového PDF. Vracia dict, nikdy nevyhadzuje."""
+    try:
+        import pdfplumber
+    except ImportError:
+        return {"ok": False, "error": "pdf_unavailable"}
+
+    try:
+        with pdfplumber.open(io.BytesIO(data)) as pdf:
+            pages = pdf.pages[:4]
+            text  = " ".join((p.extract_text() or "") for p in pages)
+            year  = _guess_year(text, today)
+            fills, borders, mapped = {}, defaultdict(set), 0
+            for page in pages:
+                cells = _cell_dates(page, year)
+                mapped += len(cells)
+                if not cells:
+                    continue
+                f, b = _marks_by_date(page, cells)
+                fills.update(f)
+                for d, e in b.items():
+                    borders[d] |= e
+    except Exception as e:                       # poškodené PDF, heslo, …
+        log.warning("Parsovanie PDF zlyhalo: {}".format(e))
+        return {"ok": False, "error": "pdf_parse_failed"}
+
+    if mapped < MIN_MAPPED_DAYS:
+        return {"ok": False, "error": "no_calendar_found", "year": year}
+    series = _build_series(fills, borders, lang)
+    if not series:
+        return {"ok": False, "error": "no_marks_found", "year": year}
+    return {"ok": True, "source": "pdf", "year": year, "series": series}
+
+
+# ── Záložná cesta cez vision model ───────────────────────────────────────────
+
+_VISION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "year": {"type": "integer"},
+        "series": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "colour_name": {"type": "string"},
+                    "fill": {"type": "string"},
+                    "suggested_type": {
+                        "type": "string",
+                        "enum": ["mixed", "bio", "plastic", "paper", "glass",
+                                 "metal", "tetrapak", "electro", "bulky", "other"],
+                    },
+                    "dates": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["colour_name", "fill", "suggested_type", "dates"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["year", "series"],
+    "additionalProperties": False,
+}
+
+_VISION_PROMPT = """Toto je obecný harmonogram vývozu odpadu.
+
+Vytiahni z neho VŠETKY termíny vývozu. Jeden "rad" (series) = jedna kombinácia
+farby/značky, ktorá v kalendári označuje jeden druh vývozu.
+
+Pravidlá:
+- dátumy vracaj ako YYYY-MM-DD
+- rok urči z dokumentu; ak tam nie je, použi {year}
+- ak dokument obsahuje viac variantov toho istého odpadu (napr. dvojtýždňový
+  a mesačný zvoz zmesového odpadu), vráť ich ako SAMOSTATNÉ rady – nezlučuj ich
+- `fill` je farba značky ako #rrggbb, `colour_name` jej názov tak, ako je
+  pomenovaná v legende (napr. "čierna nádoba")
+- nič nedomýšľaj: vráť len dni, ktoré sú v dokumente naozaj označené
+"""
+
+
+def parse_with_vision(data, media_type, lang="sk", api_key=None, model="claude-opus-5",
+                      today=None):
+    """Záloha pre skeny, fotky a PDF, ktorých rozloženie parser nepozná."""
+    api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        return {"ok": False, "error": "no_api_key"}
+    try:
+        import anthropic
+    except ImportError:
+        return {"ok": False, "error": "vision_unavailable"}
+
+    year  = (today or date.today()).year
+    block = ({"type": "document",
+              "source": {"type": "base64", "media_type": "application/pdf",
+                         "data": base64.b64encode(data).decode("ascii")}}
+             if media_type == "application/pdf" else
+             {"type": "image",
+              "source": {"type": "base64", "media_type": media_type,
+                         "data": base64.b64encode(data).decode("ascii")}})
+    try:
+        client = anthropic.Anthropic(api_key=api_key)
+        resp = client.messages.create(
+            model=model,
+            max_tokens=16000,
+            thinking={"type": "adaptive"},
+            output_config={"format": {"type": "json_schema", "schema": _VISION_SCHEMA}},
+            messages=[{"role": "user", "content": [
+                block, {"type": "text", "text": _VISION_PROMPT.format(year=year)}]}],
+        )
+        if getattr(resp, "stop_reason", "") == "refusal":
+            return {"ok": False, "error": "vision_refused"}
+        raw = json.loads(next(b.text for b in resp.content if b.type == "text"))
+    except Exception as e:
+        log.warning("Vision extrakcia zlyhala: {}".format(e))
+        return {"ok": False, "error": "vision_failed"}
+
+    series = []
+    for item in (raw.get("series") or [])[:MAX_SERIES]:
+        dates = sorted({d for d in (item.get("dates") or [])
+                        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", str(d))})[:MAX_DATES]
+        if not dates:
+            continue
+        parsed = [date(*map(int, d.split("-"))) for d in dates]
+        fill = str(item.get("fill") or "")
+        series.append({
+            "id":             "v{}".format(len(series) + 1),
+            "fill":           fill if re.fullmatch(r"#[0-9a-fA-F]{6}", fill) else "#9aa5b1",
+            "outline":        "",
+            "colour_name":    str(item.get("colour_name") or "")[:40],
+            "suggested_type": str(item.get("suggested_type") or "other"),
+            "dates":          dates,
+            "count":          len(dates),
+            "summary":        _summarise(parsed, lang),
+        })
+    if not series:
+        return {"ok": False, "error": "no_marks_found"}
+    return {"ok": True, "source": "vision",
+            "year": int(raw.get("year") or year), "series": series}

--- a/snapframe/rootfs/usr/bin/webserver.py
+++ b/snapframe/rootfs/usr/bin/webserver.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 """
-SnapFrame – webový server v2.9
+SnapFrame – webový server v2.10
 Novinky v2.6: multi-language (SK/EN/DE), sleep schedule (čierna obrazovka v noci)
 Novinky v2.7: nastavenia v appke – voliteľná hviezdna obloha (namiesto čiernej) počas sleep režimu
 Novinky v2.8: weather mode – pohybovým senzorom (cez HA automatizáciu) spúšťaná obrazovka
               s aktuálnym počasím a predpoveďou, vkladaná periodicky medzi fotky
 Novinky v2.9: weather mode – hodinová predpoveď na najbližších ~12 h (pás s časom,
               ikonou a teplotou); min/max sa dopočíta z hodinovej predpovede
+Novinky v2.10: kalendár vývozu odpadu – termíny zvozov sa nastavia priamo v appke
+              (pravidlá typu „každý druhý štvrtok“ / „prvý pondelok v mesiaci“ /
+              konkrétne dátumy) a deň vopred sa na fotkách zobrazí pripomienka –
+              buď štítok v rohu, alebo celoobrazovkový slide medzi fotkami
 """
 
 import os
@@ -18,7 +22,7 @@ import time
 import urllib.request
 from collections import OrderedDict
 from pathlib import Path
-from datetime import datetime
+from datetime import date, datetime, timedelta
 
 from flask import Flask, send_from_directory, jsonify, Response, request
 from PIL import Image, ImageOps
@@ -63,6 +67,13 @@ try:
     _has_state = True
 except ImportError:
     _has_state = False
+
+try:
+    import waste as _waste
+    _has_waste = True
+except ImportError:               # pragma: no cover – modul je súčasťou image-u
+    _has_waste = False
+    log.warning("Modul waste.py sa nepodarilo načítať – kalendár odpadu je vypnutý")
 
 # ── LRU Cache (250 položiek) ──────────────────────────────────────────────────
 class _LRUCache:
@@ -130,6 +141,64 @@ TRANSLATIONS = {
         "weather_high":         "Max",
         "weather_low":          "Min",
         "weather_humidity":     "Vlhkos\u0165",
+        # — Kalendár vývozu odpadu —
+        "waste_open_btn":       "Vývoz odpadu…",
+        "waste_title":          "Vývoz odpadu",
+        "waste_enabled_label":  "Pripomienka vývozu",
+        "waste_on":             "Zapnuté",
+        "waste_off":            "Vypnuté",
+        "waste_display_label":  "Ako zobraziť pripomienku",
+        "waste_mode_overlay":   "Štítok v rohu",
+        "waste_mode_slide":     "Celá obrazovka",
+        "waste_mode_both":      "Oboje",
+        "waste_interval_label": "Celá obrazovka každých … fotiek",
+        "waste_days_label":     "Upozorniť dní vopred",
+        "waste_show_on_day":    "Pripomenúť aj v deň vývozu",
+        "waste_start_hour":     "Pripomienku zobrazovať až od",
+        "waste_rules_label":    "Zvozy",
+        "waste_add_rule":       "+ Pridať zvoz",
+        "waste_no_rules":       "Zatiaľ nie sú nastavené žiadne zvozy.",
+        "waste_type_label":     "Druh odpadu",
+        "waste_name_label":     "Vlastný názov (nepovinné)",
+        "waste_recurrence":     "Opakovanie",
+        "waste_kind_weekly":    "Každý N-tý týždeň",
+        "waste_kind_monthly":   "Mesačne",
+        "waste_kind_dates":     "Konkrétne dátumy",
+        "waste_weekday":        "Deň v týždni",
+        "waste_every_weeks":    "Každých … týždňov",
+        "waste_anchor":         "Referenčný dátum (jeden zo zvozov)",
+        "waste_anchor_hint":    "Podľa neho sa počíta, ktorý týždeň je „ten správny“.",
+        "waste_monthly_by":     "Určiť podľa",
+        "waste_by_weekday":     "Poradia v mesiaci",
+        "waste_by_day":         "Čísla dňa",
+        "waste_week_of_month":  "Ktorý týždeň",
+        "waste_day_of_month":   "Deň v mesiaci",
+        "waste_months":         "Len v mesiacoch (nepovinné)",
+        "waste_dates_label":    "Dátumy vývozu",
+        "waste_add_date":       "Pridať",
+        "waste_valid_from":     "Platí od (nepovinné)",
+        "waste_valid_to":       "Platí do (nepovinné)",
+        "waste_skip_label":     "Výnimky – v tieto dni sa nevyváža",
+        "waste_extra_label":    "Mimoriadne termíny navyše",
+        "waste_save":           "Uložiť",
+        "waste_cancel":         "Zrušiť",
+        "waste_delete":         "Odstrániť",
+        "waste_saved":          "✓ Uložené",
+        "waste_save_err":       "Uloženie zlyhalo",
+        "waste_preview":        "Najbližšie vývozy",
+        "waste_preview_none":   "Žiadne naplánované vývozy",
+        "waste_today":          "Dnes",
+        "waste_tomorrow":       "Zajtra",
+        "waste_in_days_few":    "O {0} dni",
+        "waste_in_days_many":   "O {0} dní",
+        "waste_headline":       "vývoz odpadu",
+        "waste_hint":           "Nezabudni večer vyložiť kontajner na ulicu",
+        "waste_hint_today":     "Kontajner má byť už na ulici",
+        "waste_every_week":     "každý týždeň",
+        "waste_every_n_weeks":  "každý {0}. týždeň",
+        "waste_dates_one":      "{0} dátum",
+        "waste_dates_few":      "{0} dátumy",
+        "waste_dates_many":     "{0} dátumov",
     },
     "en": {
         "app_title":            "SnapFrame",
@@ -170,6 +239,64 @@ TRANSLATIONS = {
         "weather_high":         "High",
         "weather_low":          "Low",
         "weather_humidity":     "Humidity",
+        # — Waste collection calendar —
+        "waste_open_btn":       "Waste collection…",
+        "waste_title":          "Waste collection",
+        "waste_enabled_label":  "Collection reminder",
+        "waste_on":             "On",
+        "waste_off":            "Off",
+        "waste_display_label":  "How to show the reminder",
+        "waste_mode_overlay":   "Corner badge",
+        "waste_mode_slide":     "Full screen",
+        "waste_mode_both":      "Both",
+        "waste_interval_label": "Full screen every … photos",
+        "waste_days_label":     "Remind days ahead",
+        "waste_show_on_day":    "Also remind on collection day",
+        "waste_start_hour":     "Show the reminder only from",
+        "waste_rules_label":    "Collections",
+        "waste_add_rule":       "+ Add collection",
+        "waste_no_rules":       "No collections configured yet.",
+        "waste_type_label":     "Waste type",
+        "waste_name_label":     "Custom name (optional)",
+        "waste_recurrence":     "Repeats",
+        "waste_kind_weekly":    "Every N weeks",
+        "waste_kind_monthly":   "Monthly",
+        "waste_kind_dates":     "Specific dates",
+        "waste_weekday":        "Day of week",
+        "waste_every_weeks":    "Every … weeks",
+        "waste_anchor":         "Reference date (one collection day)",
+        "waste_anchor_hint":    "Used to work out which week is the “right” one.",
+        "waste_monthly_by":     "Determined by",
+        "waste_by_weekday":     "Position in month",
+        "waste_by_day":         "Day number",
+        "waste_week_of_month":  "Which week",
+        "waste_day_of_month":   "Day of month",
+        "waste_months":         "Only in months (optional)",
+        "waste_dates_label":    "Collection dates",
+        "waste_add_date":       "Add",
+        "waste_valid_from":     "Valid from (optional)",
+        "waste_valid_to":       "Valid until (optional)",
+        "waste_skip_label":     "Exceptions – no collection on",
+        "waste_extra_label":    "Extra one-off collections",
+        "waste_save":           "Save",
+        "waste_cancel":         "Cancel",
+        "waste_delete":         "Delete",
+        "waste_saved":          "✓ Saved",
+        "waste_save_err":       "Saving failed",
+        "waste_preview":        "Next collections",
+        "waste_preview_none":   "No collections scheduled",
+        "waste_today":          "Today",
+        "waste_tomorrow":       "Tomorrow",
+        "waste_in_days_few":    "In {0} days",
+        "waste_in_days_many":   "In {0} days",
+        "waste_headline":       "waste collection",
+        "waste_hint":           "Remember to put the bin out tonight",
+        "waste_hint_today":     "The bin should already be out",
+        "waste_every_week":     "every week",
+        "waste_every_n_weeks":  "every {0} weeks",
+        "waste_dates_one":      "{0} date",
+        "waste_dates_few":      "{0} dates",
+        "waste_dates_many":     "{0} dates",
     },
     "de": {
         "app_title":            "SnapFrame",
@@ -210,6 +337,64 @@ TRANSLATIONS = {
         "weather_high":         "Hoch",
         "weather_low":          "Tief",
         "weather_humidity":     "Feuchtigkeit",
+        # — Abfallkalender —
+        "waste_open_btn":       "Abfuhrkalender…",
+        "waste_title":          "Abfuhrkalender",
+        "waste_enabled_label":  "Abfuhr-Erinnerung",
+        "waste_on":             "Ein",
+        "waste_off":            "Aus",
+        "waste_display_label":  "Wie soll erinnert werden",
+        "waste_mode_overlay":   "Schild in der Ecke",
+        "waste_mode_slide":     "Vollbild",
+        "waste_mode_both":      "Beides",
+        "waste_interval_label": "Vollbild alle … Fotos",
+        "waste_days_label":     "Tage im Voraus erinnern",
+        "waste_show_on_day":    "Auch am Abfuhrtag erinnern",
+        "waste_start_hour":     "Erinnerung erst ab",
+        "waste_rules_label":    "Abfuhren",
+        "waste_add_rule":       "+ Abfuhr hinzufügen",
+        "waste_no_rules":       "Noch keine Abfuhren eingerichtet.",
+        "waste_type_label":     "Abfallart",
+        "waste_name_label":     "Eigener Name (optional)",
+        "waste_recurrence":     "Wiederholung",
+        "waste_kind_weekly":    "Alle N Wochen",
+        "waste_kind_monthly":   "Monatlich",
+        "waste_kind_dates":     "Bestimmte Daten",
+        "waste_weekday":        "Wochentag",
+        "waste_every_weeks":    "Alle … Wochen",
+        "waste_anchor":         "Referenzdatum (ein Abfuhrtag)",
+        "waste_anchor_hint":    "Damit wird berechnet, welche Woche die „richtige“ ist.",
+        "waste_monthly_by":     "Festgelegt durch",
+        "waste_by_weekday":     "Position im Monat",
+        "waste_by_day":         "Tagesnummer",
+        "waste_week_of_month":  "Welche Woche",
+        "waste_day_of_month":   "Tag im Monat",
+        "waste_months":         "Nur in Monaten (optional)",
+        "waste_dates_label":    "Abfuhrtermine",
+        "waste_add_date":       "Hinzufügen",
+        "waste_valid_from":     "Gültig ab (optional)",
+        "waste_valid_to":       "Gültig bis (optional)",
+        "waste_skip_label":     "Ausnahmen – keine Abfuhr am",
+        "waste_extra_label":    "Zusätzliche Sondertermine",
+        "waste_save":           "Speichern",
+        "waste_cancel":         "Abbrechen",
+        "waste_delete":         "Löschen",
+        "waste_saved":          "✓ Gespeichert",
+        "waste_save_err":       "Speichern fehlgeschlagen",
+        "waste_preview":        "Nächste Abfuhren",
+        "waste_preview_none":   "Keine Abfuhren geplant",
+        "waste_today":          "Heute",
+        "waste_tomorrow":       "Morgen",
+        "waste_in_days_few":    "In {0} Tagen",
+        "waste_in_days_many":   "In {0} Tagen",
+        "waste_headline":       "Abfuhr",
+        "waste_hint":           "Denk daran, die Tonne heute Abend rauszustellen",
+        "waste_hint_today":     "Die Tonne sollte schon draußen stehen",
+        "waste_every_week":     "jede Woche",
+        "waste_every_n_weeks":  "alle {0} Wochen",
+        "waste_dates_one":      "{0} Termin",
+        "waste_dates_few":      "{0} Termine",
+        "waste_dates_many":     "{0} Termine",
     },
 }
 
@@ -220,6 +405,25 @@ MONTHS = {
            "July","August","September","October","November","December"],
     "de": ["Januar","Februar","März","April","Mai","Juni",
            "Juli","August","September","Oktober","November","Dezember"],
+}
+
+WEEKDAYS = {
+    "sk": ["Pondelok","Utorok","Streda","\u0160tvrtok","Piatok","Sobota","Nede\u013ea"],
+    "en": ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"],
+    "de": ["Montag","Dienstag","Mittwoch","Donnerstag","Freitag","Samstag","Sonntag"],
+}
+
+WEEKDAYS_SHORT = {
+    "sk": ["Po","Ut","St","\u0160t","Pi","So","Ne"],
+    "en": ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"],
+    "de": ["Mo","Di","Mi","Do","Fr","Sa","So"],
+}
+
+# Poradie t\u00fd\u017ed\u0148a v mesiaci (1..5 a -1 = posledn\u00fd) pre popis pravidla
+WEEK_ORDINALS = {
+    "sk": {"1": "prv\u00fd", "2": "druh\u00fd", "3": "tret\u00ed", "4": "\u0161tvrt\u00fd", "5": "piaty", "-1": "posledn\u00fd"},
+    "en": {"1": "first", "2": "second", "3": "third", "4": "fourth", "5": "fifth", "-1": "last"},
+    "de": {"1": "erster", "2": "zweiter", "3": "dritter", "4": "vierter", "5": "f\u00fcnfter", "-1": "letzter"},
 }
 
 GEOCODE_LANG = {"sk": "sk,cs,en", "en": "en", "de": "de,en"}
@@ -726,6 +930,84 @@ def weather_route():
         status["data"]["condition_label"] = WEATHER_CONDITIONS.get(lang, {}).get(cond, cond)
     return jsonify(status)
 
+# ── Kalendár vývozu odpadu ─────────────────────────────────────
+
+def _waste_lang():
+    return LANGUAGE if LANGUAGE in TRANSLATIONS else "sk"
+
+@app.route("/waste/config")
+def waste_config_route():
+    """Celá konfigurácia + katalóg druhov odpadu – pre editor v appke."""
+    if not _has_waste:
+        return jsonify({"ok": False, "error": "unavailable"}), 503
+    lang = _waste_lang()
+    return jsonify({
+        "ok":      True,
+        "config":  _waste.load_config(),
+        "types":   _waste.type_catalog(lang),
+        "max_rules": _waste.MAX_RULES,
+    })
+
+@app.route("/waste/config", methods=["POST"])
+def waste_config_save_route():
+    if not _has_waste:
+        return jsonify({"ok": False, "error": "unavailable"}), 503
+    raw = request.get_json(silent=True)
+    if raw is None:
+        return jsonify({"ok": False, "error": "no data"}), 400
+    try:
+        cfg = _waste.save_config(raw)
+    except Exception as e:
+        log.error("Uloženie kalendára odpadu zlyhalo: {}".format(e))
+        return jsonify({"ok": False, "error": "save failed"}), 500
+    log.info("Kalendár odpadu uložený: {} pravidiel, režim {}, {}".format(
+        len(cfg["rules"]), cfg["mode"], "zapnutý" if cfg["enabled"] else "vypnutý"))
+    return jsonify({"ok": True, "config": cfg})
+
+@app.route("/waste/status")
+def waste_status_route():
+    """Čo sa vyváža v najbližších dňoch.
+
+    Zámerne posielame surový zoznam termínov a nie hotovú hlášku „zajtra sa
+    vyváža…“ – čo je „dnešok“ si rozhodne prehliadač na tablete, ktorý má
+    na rozdiel od kontajnera add-onu spoľahlivo správnu lokálnu časovú zónu.
+    Okno začína 2 dni v minulosti, aby posun TZ nikdy neodrežal dnešný termín.
+    """
+    if not _has_waste:
+        return jsonify({"enabled": False, "upcoming": []})
+    cfg  = _waste.load_config()
+    lang = _waste_lang()
+    return jsonify({
+        "enabled":        cfg["enabled"],
+        "mode":           cfg["mode"],
+        "photo_interval": cfg["photo_interval"],
+        "days_before":    cfg["days_before"],
+        "show_on_day":    cfg["show_on_day"],
+        "start_hour":     cfg["start_hour"],
+        "upcoming":       _waste.occurrences(cfg, date.today() - timedelta(days=2),
+                                             _waste.UPCOMING_DAYS, lang),
+    })
+
+@app.route("/waste/next")
+def waste_next_route():
+    """Najbližší vývoz – pre REST senzor / automatizácie v Home Assistante."""
+    if not _has_waste:
+        return jsonify({"ok": False, "error": "unavailable"}), 503
+    cfg = _waste.load_config()
+    nxt = _waste.next_collection(cfg, date.today(), _waste_lang())
+    if not nxt:
+        return jsonify({"ok": True, "state": "", "date": "", "days_until": None,
+                        "types": [], "text": ""})
+    labels = [t["label"] for t in nxt["types"]]
+    return jsonify({
+        "ok":         True,
+        "state":      nxt["date"],
+        "date":       nxt["date"],
+        "days_until": nxt["days_until"],
+        "types":      nxt["types"],
+        "text":       ", ".join(labels),
+    })
+
 # ── HTML ──────────────────────────────────────────────────────────────────────
 
 @app.route("/")
@@ -1052,6 +1334,205 @@ html, body {
     margin-top: 24px; margin-top: clamp(16px, 3vh, 34px); bottom: auto;
   }
 }
+/* ===== ODPAD: štítok v rohu fotky ===== */
+/* Rovnaký princíp ako weather slide: vždy px fallback pred clamp(),
+   žiadny flex `gap` – starý iPad Safari (9–13) ich nepozná. */
+#waste-badge {
+  position: absolute; top: 16px; left: 18px; z-index: 95;
+  display: none; max-width: 62%;
+  background: rgba(8,10,14,0.62);
+  border-radius: 14px; border-radius: clamp(12px, 1.2vw, 18px);
+  border-left: 6px solid #9aa5b1;
+  padding: 12px 18px 12px 14px;
+  padding: clamp(9px, 1.4vh, 18px) clamp(13px, 1.5vw, 24px) clamp(9px, 1.4vh, 18px) clamp(10px, 1.1vw, 18px);
+  -webkit-box-sizing: border-box; box-sizing: border-box;
+  text-shadow: 0 2px 8px rgba(0,0,0,0.9);
+  pointer-events: none;
+}
+#waste-badge.visible { display: block; }
+.wb-row { display: table; width: 100%; }
+.wb-ico {
+  display: table-cell; vertical-align: middle; padding-right: 12px;
+  font-size: 38px; font-size: clamp(30px, 3.4vw, 54px); line-height: 1;
+}
+.wb-text { display: table-cell; vertical-align: middle; text-align: left; }
+.wb-when {
+  font-size: 13px; font-size: clamp(11px, 1.1vw, 17px);
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: rgba(255,255,255,0.55); margin-bottom: 3px;
+}
+.wb-what {
+  font-size: 26px; font-size: clamp(20px, 2.2vw, 36px);
+  font-weight: 300; color: #fff; line-height: 1.15;
+}
+/* ===== ODPAD: celoobrazovkový slide ===== */
+#waste-slide {
+  position: absolute; top: 0; left: 0; right: 0; bottom: 0; z-index: 82;
+  background:
+    radial-gradient(ellipse at 50% 28%, #1d3324 0%, #0c1712 55%, #05080b 100%);
+  display: none; -webkit-flex-direction: column; flex-direction: column;
+  align-items: center; justify-content: center; text-align: center;
+  padding: 4vh 5vw; -webkit-box-sizing: border-box; box-sizing: border-box;
+  opacity: 0; -webkit-transition: opacity 1s ease-in-out; transition: opacity 1s ease-in-out;
+}
+#waste-slide.visible { display: block; display: -webkit-flex; display: flex; opacity: 1; }
+.waste-when {
+  font-size: 24px; font-size: clamp(18px, 2.4vw, 38px);
+  letter-spacing: 0.26em; text-transform: uppercase;
+  color: rgba(255,255,255,0.55);
+  margin-bottom: 18px; margin-bottom: clamp(10px, 2vh, 30px);
+}
+.waste-icons {
+  font-size: 110px; font-size: clamp(70px, 13vw, 168px); line-height: 1.05;
+  filter: drop-shadow(0 8px 26px rgba(0,0,0,0.6));
+  -webkit-filter: drop-shadow(0 8px 26px rgba(0,0,0,0.6));
+}
+.waste-names {
+  font-size: 58px; font-size: clamp(34px, 6.4vw, 96px);
+  font-weight: 200; letter-spacing: -0.01em; color: #fff; line-height: 1.1;
+  margin-top: 16px; margin-top: clamp(8px, 1.8vh, 26px);
+  text-shadow: 0 3px 30px rgba(0,0,0,0.5);
+}
+.waste-names .wn-sep { color: rgba(255,255,255,0.32); }
+.waste-accent {
+  width: 120px; width: clamp(80px, 11vw, 190px);
+  height: 6px; height: clamp(4px, 0.6vh, 9px);
+  border-radius: 4px; background: #7cb342;
+  margin: 26px auto 0; margin-top: clamp(16px, 2.6vh, 36px);
+}
+.waste-hint {
+  font-size: 22px; font-size: clamp(16px, 2vw, 32px); font-weight: 300;
+  color: rgba(255,255,255,0.7);
+  margin-top: 26px; margin-top: clamp(15px, 2.6vh, 38px);
+  max-width: 900px;
+}
+.waste-date {
+  position: absolute; bottom: 28px; bottom: clamp(20px, 3.5vh, 44px);
+  left: 0; right: 0; text-align: center;
+  font-size: 15px; font-size: clamp(13px, 1.4vw, 20px);
+  letter-spacing: 0.22em; text-transform: uppercase;
+  color: rgba(255,255,255,0.32);
+}
+@media (orientation: portrait) {
+  .waste-names { font-size: 46px; font-size: clamp(30px, 9vw, 62px); }
+  .waste-icons { font-size: 96px; font-size: clamp(64px, 20vw, 130px); }
+  .waste-when  { font-size: 20px; font-size: clamp(15px, 4vw, 26px); }
+  .waste-hint  { font-size: 20px; font-size: clamp(15px, 4vw, 26px); }
+  .waste-date  { position: static; margin-top: 26px; }
+}
+/* ===== ODPAD: editor kalendára ===== */
+#waste-dialog {
+  position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+  z-index: 400; background: #0c0c0c; display: none;
+  overflow-y: auto; -webkit-overflow-scrolling: touch;
+  padding: 26px 18px 40px; -webkit-box-sizing: border-box; box-sizing: border-box;
+}
+.wd-inner { max-width: 560px; margin: 0 auto; text-align: left; }
+.wd-title {
+  font-size: 13px; letter-spacing: 2.5px; text-transform: uppercase;
+  color: #777; margin-bottom: 22px; text-align: center;
+}
+.wd-group { margin-bottom: 22px; }
+.wd-label {
+  font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase;
+  color: #555; margin-bottom: 9px;
+}
+.wd-hint { font-size: 11px; line-height: 1.5; color: #4a4a4a; margin-top: 6px; }
+.wd-seg { display: block; width: 100%; font-size: 0; }
+.wd-seg .wd-opt {
+  display: inline-block; -webkit-box-sizing: border-box; box-sizing: border-box;
+  background: #171717; border: 1.5px solid #272727; border-radius: 10px;
+  padding: 11px 6px; text-align: center; color: #8b8b8b; font-size: 14px;
+  cursor: pointer; outline: none; -webkit-tap-highlight-color: transparent;
+  margin: 0 2% 8px 0; vertical-align: top;
+  -webkit-transition: border-color .15s, background .15s, color .15s;
+  transition: border-color .15s, background .15s, color .15s;
+}
+/* Šírky sú zámerne pod matematickým maximom: každá dlaždica má margin-right,
+   takže riadok musí vyjsť aj bez spoliehania sa na :last-child – inak by pri
+   10 druhoch odpadu vyšli riadky raz po 3 a raz po 4 kusoch. */
+.wd-seg.cols2 .wd-opt { width: 47.8%; }
+.wd-seg.cols3 .wd-opt { width: 31%; }
+.wd-seg.cols4 .wd-opt { width: 22.7%; }
+.wd-seg.cols7 .wd-opt { width: 12.1%; padding: 11px 2px; font-size: 13px; }
+.wd-seg .wd-opt.active { border-color: #4a7fd6; background: #1a2333; color: #dce6fb; }
+.wd-input, .wd-select {
+  width: 100%; -webkit-box-sizing: border-box; box-sizing: border-box;
+  background: #171717; border: 1px solid #272727; border-radius: 9px;
+  color: #ddd; font-size: 15px; padding: 11px 12px; outline: none;
+  -webkit-appearance: none; appearance: none;
+  font-family: -apple-system, Helvetica, Arial, sans-serif;
+}
+.wd-select { -webkit-appearance: menulist; appearance: menulist; }
+.wd-stepper { display: table; width: 100%; }
+.wd-stepper .wd-step-btn {
+  display: table-cell; width: 54px; text-align: center; vertical-align: middle;
+  background: #1c1c1c; border: 1px solid #2a2a2a; border-radius: 9px;
+  color: #bbb; font-size: 22px; line-height: 1; padding: 10px 0;
+  cursor: pointer; outline: none; -webkit-tap-highlight-color: transparent;
+  -webkit-user-select: none; user-select: none;
+}
+.wd-stepper .wd-step-val {
+  display: table-cell; text-align: center; vertical-align: middle;
+  color: #fff; font-size: 19px; font-weight: 300;
+}
+.wd-check {
+  display: table; width: 100%; background: #171717; border: 1px solid #262626;
+  border-radius: 10px; padding: 12px 14px; -webkit-box-sizing: border-box;
+  box-sizing: border-box; cursor: pointer; -webkit-tap-highlight-color: transparent;
+}
+.wd-check .wc-txt { display: table-cell; vertical-align: middle; color: #bbb; font-size: 14px; }
+.wd-check .wc-box {
+  display: table-cell; vertical-align: middle; width: 26px; text-align: right;
+  color: #3a3a3a; font-size: 18px;
+}
+.wd-check.on .wc-box { color: #5b9bf8; }
+.wd-check.on .wc-txt { color: #e6e6e6; }
+.wd-rule {
+  display: table; width: 100%; background: #151515; border: 1px solid #232323;
+  border-left-width: 5px; border-radius: 11px; padding: 13px 14px; margin-bottom: 9px;
+  -webkit-box-sizing: border-box; box-sizing: border-box;
+  cursor: pointer; -webkit-tap-highlight-color: transparent;
+}
+.wd-rule .wr-ico { display: table-cell; vertical-align: middle; width: 40px; font-size: 25px; }
+.wd-rule .wr-txt { display: table-cell; vertical-align: middle; }
+.wd-rule .wr-name { color: #eee; font-size: 15px; margin-bottom: 2px; }
+.wd-rule .wr-sub  { color: #6b6b6b; font-size: 12px; line-height: 1.4; }
+.wd-rule .wr-go   { display: table-cell; vertical-align: middle; width: 22px;
+                    text-align: right; color: #444; font-size: 17px; }
+.wd-empty { color: #4a4a4a; font-size: 13px; padding: 14px 2px; }
+.wd-btn {
+  display: block; width: 100%; -webkit-box-sizing: border-box; box-sizing: border-box;
+  padding: 13px; border-radius: 10px; font-size: 15px; text-align: center;
+  cursor: pointer; outline: none; -webkit-tap-highlight-color: transparent;
+  border: 1px solid #2c2c2c; background: #202020; color: #ccc; margin-bottom: 9px;
+}
+.wd-btn.primary { background: #24457c; border-color: #2f5da8; color: #eaf1ff; }
+.wd-btn.danger  { background: #2a1616; border-color: #4a2020; color: #d98a8a; }
+.wd-btn.ghost   { background: transparent; border-color: #262626; color: #777; }
+.wd-status { font-size: 13px; text-align: center; min-height: 18px; margin-bottom: 8px; color: #888; }
+.wd-status.ok  { color: #4caf50; }
+.wd-status.err { color: #d9534f; }
+.wd-chips { font-size: 0; }
+.wd-chip {
+  display: inline-block; background: #1b1b1b; border: 1px solid #2a2a2a;
+  border-radius: 20px; padding: 7px 12px; margin: 0 6px 6px 0;
+  color: #bbb; font-size: 13px; cursor: pointer; -webkit-tap-highlight-color: transparent;
+}
+.wd-chip .wc-x { color: #666; margin-left: 7px; }
+.wd-chip.month.on { background: #1a2333; border-color: #4a7fd6; color: #dce6fb; }
+.wd-daterow { display: table; width: 100%; }
+.wd-daterow .wd-dcell { display: table-cell; vertical-align: middle; }
+.wd-daterow .wd-dbtn  {
+  display: table-cell; vertical-align: middle; width: 90px; padding-left: 8px;
+}
+.wd-preview-day {
+  display: table; width: 100%; padding: 9px 0; border-bottom: 1px solid #1c1c1c;
+}
+.wd-preview-day .wp-date { display: table-cell; vertical-align: middle; width: 45%;
+                           color: #9a9a9a; font-size: 13px; }
+.wd-preview-day .wp-types { display: table-cell; vertical-align: middle;
+                            color: #ddd; font-size: 13px; text-align: right; }
 /* ===== SETTINGS ===== */
 .settings-btn {
   position: absolute; top: 18px; right: 18px; z-index: 60;
@@ -1219,7 +1700,209 @@ html, body {
         </div>
       </div>
     </div>
+    <div class="settings-group">
+      <button class="wd-btn" id="t-waste-open-btn" onclick="openWasteDialog()"></button>
+    </div>
     <button class="settings-close" id="t-settings-close" onclick="closeSettings()"></button>
+  </div>
+</div>
+
+<!-- EDITOR KALENDÁRA VÝVOZU ODPADU -->
+<div id="waste-dialog">
+  <div class="wd-inner">
+    <div class="wd-title" id="t-waste-title"></div>
+
+    <!-- prehľad + globálne nastavenia -->
+    <div id="waste-main">
+      <div class="wd-group">
+        <div class="wd-label" id="t-waste-enabled-label"></div>
+        <div class="wd-seg cols2" id="waste-enabled-seg">
+          <div class="wd-opt" id="waste-en-off" onclick="wdSetEnabled(0)"></div>
+          <div class="wd-opt" id="waste-en-on"  onclick="wdSetEnabled(1)"></div>
+        </div>
+      </div>
+
+      <div class="wd-group">
+        <div class="wd-label" id="t-waste-display-label"></div>
+        <div class="wd-seg cols3" id="waste-mode-seg">
+          <div class="wd-opt" id="waste-mode-overlay" onclick="wdSetMode('overlay')"></div>
+          <div class="wd-opt" id="waste-mode-slide"   onclick="wdSetMode('slide')"></div>
+          <div class="wd-opt" id="waste-mode-both"    onclick="wdSetMode('both')"></div>
+        </div>
+      </div>
+
+      <div class="wd-group" id="waste-interval-group">
+        <div class="wd-label" id="t-waste-interval-label"></div>
+        <div class="wd-stepper">
+          <div class="wd-step-btn" onclick="wdStep('photo_interval',-1,2,100)">&minus;</div>
+          <div class="wd-step-val" id="waste-interval-val"></div>
+          <div class="wd-step-btn" onclick="wdStep('photo_interval',1,2,100)">+</div>
+        </div>
+      </div>
+
+      <div class="wd-group">
+        <div class="wd-label" id="t-waste-days-label"></div>
+        <div class="wd-stepper">
+          <div class="wd-step-btn" onclick="wdStep('days_before',-1,0,7)">&minus;</div>
+          <div class="wd-step-val" id="waste-days-val"></div>
+          <div class="wd-step-btn" onclick="wdStep('days_before',1,0,7)">+</div>
+        </div>
+      </div>
+
+      <div class="wd-group">
+        <div class="wd-check" id="waste-showday-check" onclick="wdToggleShowOnDay()">
+          <div class="wc-txt" id="t-waste-show-on-day"></div>
+          <div class="wc-box">&#10003;</div>
+        </div>
+      </div>
+
+      <div class="wd-group">
+        <div class="wd-label" id="t-waste-start-hour"></div>
+        <div class="wd-stepper">
+          <div class="wd-step-btn" onclick="wdStep('start_hour',-1,0,23)">&minus;</div>
+          <div class="wd-step-val" id="waste-hour-val"></div>
+          <div class="wd-step-btn" onclick="wdStep('start_hour',1,0,23)">+</div>
+        </div>
+      </div>
+
+      <div class="wd-group">
+        <div class="wd-label" id="t-waste-rules-label"></div>
+        <div id="waste-rule-list"></div>
+        <button class="wd-btn ghost" id="t-waste-add-rule" onclick="wdNewRule()"></button>
+      </div>
+
+      <div class="wd-group">
+        <div class="wd-label" id="t-waste-preview"></div>
+        <div id="waste-preview-list"></div>
+      </div>
+
+      <div class="wd-status" id="waste-status"></div>
+      <button class="wd-btn primary" id="t-waste-save" onclick="wdSaveConfig()"></button>
+      <button class="wd-btn" id="t-waste-close" onclick="closeWasteDialog()"></button>
+    </div>
+
+    <!-- editor jedného zvozu -->
+    <div id="waste-editor" style="display:none">
+      <div class="wd-group">
+        <div class="wd-label" id="t-waste-type-label"></div>
+        <div class="wd-seg cols4" id="waste-type-seg"></div>
+      </div>
+
+      <div class="wd-group">
+        <div class="wd-label" id="t-waste-name-label"></div>
+        <input type="text" class="wd-input" id="waste-name-input" maxlength="40">
+      </div>
+
+      <div class="wd-group">
+        <div class="wd-label" id="t-waste-recurrence"></div>
+        <div class="wd-seg cols3" id="waste-kind-seg">
+          <div class="wd-opt" id="waste-kind-weekly"  onclick="wdSetKind('weekly')"></div>
+          <div class="wd-opt" id="waste-kind-monthly" onclick="wdSetKind('monthly')"></div>
+          <div class="wd-opt" id="waste-kind-dates"   onclick="wdSetKind('dates')"></div>
+        </div>
+      </div>
+
+      <!-- týždenné -->
+      <div id="waste-weekly-box">
+        <div class="wd-group">
+          <div class="wd-label" id="t-waste-weekday"></div>
+          <div class="wd-seg cols7" id="waste-weekday-seg"></div>
+        </div>
+        <div class="wd-group">
+          <div class="wd-label" id="t-waste-every-weeks"></div>
+          <div class="wd-stepper">
+            <div class="wd-step-btn" onclick="wdStepRule('interval_weeks',-1,1,12)">&minus;</div>
+            <div class="wd-step-val" id="waste-weeks-val"></div>
+            <div class="wd-step-btn" onclick="wdStepRule('interval_weeks',1,1,12)">+</div>
+          </div>
+        </div>
+        <div class="wd-group" id="waste-anchor-group">
+          <div class="wd-label" id="t-waste-anchor"></div>
+          <input type="date" class="wd-input" id="waste-anchor-input"
+                 placeholder="YYYY-MM-DD" onchange="wdReadAnchor()">
+          <div class="wd-hint" id="t-waste-anchor-hint"></div>
+        </div>
+      </div>
+
+      <!-- mesačné -->
+      <div id="waste-monthly-box" style="display:none">
+        <div class="wd-group">
+          <div class="wd-label" id="t-waste-monthly-by"></div>
+          <div class="wd-seg cols2" id="waste-by-seg">
+            <div class="wd-opt" id="waste-by-weekday" onclick="wdSetMonthlyBy('weekday')"></div>
+            <div class="wd-opt" id="waste-by-day"     onclick="wdSetMonthlyBy('day')"></div>
+          </div>
+        </div>
+        <div id="waste-by-weekday-box">
+          <div class="wd-group">
+            <div class="wd-label" id="t-waste-week-of-month"></div>
+            <select class="wd-select" id="waste-wom-select" onchange="wdReadWom()"></select>
+          </div>
+          <div class="wd-group">
+            <div class="wd-label" id="t-waste-weekday-2"></div>
+            <div class="wd-seg cols7" id="waste-weekday-seg2"></div>
+          </div>
+        </div>
+        <div class="wd-group" id="waste-by-day-box" style="display:none">
+          <div class="wd-label" id="t-waste-day-of-month"></div>
+          <div class="wd-stepper">
+            <div class="wd-step-btn" onclick="wdStepRule('day_of_month',-1,1,31)">&minus;</div>
+            <div class="wd-step-val" id="waste-dom-val"></div>
+            <div class="wd-step-btn" onclick="wdStepRule('day_of_month',1,1,31)">+</div>
+          </div>
+        </div>
+        <div class="wd-group">
+          <div class="wd-label" id="t-waste-months"></div>
+          <div class="wd-chips" id="waste-months-chips"></div>
+        </div>
+      </div>
+
+      <!-- konkrétne dátumy -->
+      <div id="waste-dates-box" style="display:none">
+        <div class="wd-group">
+          <div class="wd-label" id="t-waste-dates-label"></div>
+          <div class="wd-daterow">
+            <div class="wd-dcell"><input type="date" class="wd-input" id="waste-date-input" placeholder="YYYY-MM-DD"></div>
+            <div class="wd-dbtn"><button class="wd-btn" style="margin:0" id="t-waste-add-date"
+                 onclick="wdAddDate('dates')"></button></div>
+          </div>
+          <div class="wd-chips" id="waste-dates-chips" style="margin-top:10px"></div>
+        </div>
+      </div>
+
+      <div class="wd-group">
+        <div class="wd-label" id="t-waste-valid-from"></div>
+        <input type="date" class="wd-input" id="waste-from-input" placeholder="YYYY-MM-DD" onchange="wdReadRange()">
+      </div>
+      <div class="wd-group">
+        <div class="wd-label" id="t-waste-valid-to"></div>
+        <input type="date" class="wd-input" id="waste-to-input" placeholder="YYYY-MM-DD" onchange="wdReadRange()">
+      </div>
+
+      <div class="wd-group">
+        <div class="wd-label" id="t-waste-skip-label"></div>
+        <div class="wd-daterow">
+          <div class="wd-dcell"><input type="date" class="wd-input" id="waste-skip-input" placeholder="YYYY-MM-DD"></div>
+          <div class="wd-dbtn"><button class="wd-btn" style="margin:0" id="t-waste-add-skip"
+               onclick="wdAddDate('skip')"></button></div>
+        </div>
+        <div class="wd-chips" id="waste-skip-chips" style="margin-top:10px"></div>
+      </div>
+
+      <div class="wd-group">
+        <div class="wd-label" id="t-waste-extra-label"></div>
+        <div class="wd-daterow">
+          <div class="wd-dcell"><input type="date" class="wd-input" id="waste-extra-input" placeholder="YYYY-MM-DD"></div>
+          <div class="wd-dbtn"><button class="wd-btn" style="margin:0" id="t-waste-add-extra"
+               onclick="wdAddDate('extra')"></button></div>
+        </div>
+        <div class="wd-chips" id="waste-extra-chips" style="margin-top:10px"></div>
+      </div>
+
+      <button class="wd-btn primary" id="t-waste-rule-ok"     onclick="wdCommitRule()"></button>
+      <button class="wd-btn"         id="t-waste-rule-cancel" onclick="wdCancelRule()"></button>
+      <button class="wd-btn danger"  id="t-waste-rule-delete" onclick="wdDeleteRule()"></button>
+    </div>
   </div>
 </div>
 
@@ -1267,6 +1950,23 @@ html, body {
     <div id="overlay-date"></div>
     <div id="overlay-location"></div>
   </div>
+  <div id="waste-badge">
+    <div class="wb-row">
+      <div class="wb-ico" id="waste-badge-ico"></div>
+      <div class="wb-text">
+        <div class="wb-when" id="waste-badge-when"></div>
+        <div class="wb-what" id="waste-badge-what"></div>
+      </div>
+    </div>
+  </div>
+  <div id="waste-slide">
+    <div class="waste-when"  id="waste-slide-when"></div>
+    <div class="waste-icons" id="waste-slide-icons"></div>
+    <div class="waste-names" id="waste-slide-names"></div>
+    <div class="waste-accent" id="waste-slide-accent"></div>
+    <div class="waste-hint"  id="waste-slide-hint"></div>
+    <div class="waste-date"  id="waste-slide-date"></div>
+  </div>
   <div id="weather-slide">
     <div class="weather-hero">
       <div class="weather-icon" id="weather-icon"></div>
@@ -1297,6 +1997,10 @@ var SLIDESHOW_SECS   = __SLIDESHOW_SECS__;
 var SLEEP_START      = "__SLEEP_START__";
 var SLEEP_END        = "__SLEEP_END__";
 var WEATHER_INTERVAL = __WEATHER_INTERVAL__;
+var WEEKDAYS         = __WEEKDAYS__;
+var WEEKDAYS_SHORT   = __WEEKDAYS_SHORT__;
+var MONTHS_LIST      = __MONTHS_LIST__;
+var WEEK_ORDINALS    = __WEEK_ORDINALS__;
 
 // ── i18n helpers ──────────────────────────────────────────────────────────────
 function tr(k)       { return TR[k] || k; }
@@ -1333,6 +2037,53 @@ function applyTranslations() {
   document.getElementById("t-theme-black").textContent          = tr("theme_black");
   document.getElementById("t-theme-stars").textContent          = tr("theme_stars");
   document.getElementById("t-settings-close").textContent       = tr("settings_close");
+  // — kalendár vývozu odpadu —
+  document.getElementById("t-waste-open-btn").textContent       = tr("waste_open_btn");
+  document.getElementById("t-waste-title").textContent          = tr("waste_title");
+  document.getElementById("t-waste-enabled-label").textContent  = tr("waste_enabled_label");
+  document.getElementById("waste-en-on").textContent            = tr("waste_on");
+  document.getElementById("waste-en-off").textContent           = tr("waste_off");
+  document.getElementById("t-waste-display-label").textContent  = tr("waste_display_label");
+  document.getElementById("waste-mode-overlay").textContent     = tr("waste_mode_overlay");
+  document.getElementById("waste-mode-slide").textContent       = tr("waste_mode_slide");
+  document.getElementById("waste-mode-both").textContent        = tr("waste_mode_both");
+  document.getElementById("t-waste-interval-label").textContent = tr("waste_interval_label");
+  document.getElementById("t-waste-days-label").textContent     = tr("waste_days_label");
+  document.getElementById("t-waste-show-on-day").textContent    = tr("waste_show_on_day");
+  document.getElementById("t-waste-start-hour").textContent     = tr("waste_start_hour");
+  document.getElementById("t-waste-rules-label").textContent    = tr("waste_rules_label");
+  document.getElementById("t-waste-add-rule").textContent       = tr("waste_add_rule");
+  document.getElementById("t-waste-preview").textContent        = tr("waste_preview");
+  document.getElementById("t-waste-save").textContent           = tr("waste_save");
+  document.getElementById("t-waste-close").textContent          = tr("settings_close");
+  document.getElementById("t-waste-type-label").textContent     = tr("waste_type_label");
+  document.getElementById("t-waste-name-label").textContent     = tr("waste_name_label");
+  document.getElementById("t-waste-recurrence").textContent     = tr("waste_recurrence");
+  document.getElementById("waste-kind-weekly").textContent      = tr("waste_kind_weekly");
+  document.getElementById("waste-kind-monthly").textContent     = tr("waste_kind_monthly");
+  document.getElementById("waste-kind-dates").textContent       = tr("waste_kind_dates");
+  document.getElementById("t-waste-weekday").textContent        = tr("waste_weekday");
+  document.getElementById("t-waste-weekday-2").textContent      = tr("waste_weekday");
+  document.getElementById("t-waste-every-weeks").textContent    = tr("waste_every_weeks");
+  document.getElementById("t-waste-anchor").textContent         = tr("waste_anchor");
+  document.getElementById("t-waste-anchor-hint").textContent    = tr("waste_anchor_hint");
+  document.getElementById("t-waste-monthly-by").textContent     = tr("waste_monthly_by");
+  document.getElementById("waste-by-weekday").textContent       = tr("waste_by_weekday");
+  document.getElementById("waste-by-day").textContent           = tr("waste_by_day");
+  document.getElementById("t-waste-week-of-month").textContent  = tr("waste_week_of_month");
+  document.getElementById("t-waste-day-of-month").textContent   = tr("waste_day_of_month");
+  document.getElementById("t-waste-months").textContent         = tr("waste_months");
+  document.getElementById("t-waste-dates-label").textContent    = tr("waste_dates_label");
+  document.getElementById("t-waste-add-date").textContent       = tr("waste_add_date");
+  document.getElementById("t-waste-add-skip").textContent       = tr("waste_add_date");
+  document.getElementById("t-waste-add-extra").textContent      = tr("waste_add_date");
+  document.getElementById("t-waste-valid-from").textContent     = tr("waste_valid_from");
+  document.getElementById("t-waste-valid-to").textContent       = tr("waste_valid_to");
+  document.getElementById("t-waste-skip-label").textContent     = tr("waste_skip_label");
+  document.getElementById("t-waste-extra-label").textContent    = tr("waste_extra_label");
+  document.getElementById("t-waste-rule-ok").textContent        = tr("waste_save");
+  document.getElementById("t-waste-rule-cancel").textContent    = tr("waste_cancel");
+  document.getElementById("t-waste-rule-delete").textContent    = tr("waste_delete");
 }
 
 // ── Settings (sleep theme) ──────────────────────────────────────────────────
@@ -1466,6 +2217,7 @@ function checkSleep() {
     }
     if (advanceTimer) { clearInterval(advanceTimer); advanceTimer = null; }
     if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = null; }
+    updateWasteBadge();
   } else {
     el.style.display = "none";
     _stopMeteorShowerLoop();
@@ -1473,6 +2225,8 @@ function checkSleep() {
       startAdvanceTimer();
       _startRefreshTimer();
     }
+    // po prebudení je už možno „zajtra“ – prepočítaj pripomienku
+    fetchWasteStatus();
   }
 }
 setInterval(checkSleep, 60000);
@@ -1590,7 +2344,10 @@ function goBack() {
   document.getElementById("overlay-location").innerHTML = "";
   document.getElementById("photo-counter").innerHTML    = "";
   hideWeatherSlide();
+  hideWasteSlide();
+  document.getElementById("waste-badge").className = "";
   photosSinceWeather = 0;
+  photosSinceWaste   = 0;
   slideshowActive = false;
   document.getElementById("screen-slideshow").style.display = "none";
   document.getElementById("screen-select").style.display    = "";
@@ -1637,6 +2394,7 @@ function pickEffect() { return EFFECTS[Math.floor(Math.random() * EFFECTS.length
 function showPhoto(index) {
   if (!photos.length) { return; }
   hideWeatherSlide();
+  hideWasteSlide();
   var idx      = ((index % photos.length) + photos.length) % photos.length;
   var filename = photos[idx];
   var url      = "/thumb/" + encodePath(filename);
@@ -1652,6 +2410,7 @@ function showPhoto(index) {
   activeIsA = !activeIsA;
   document.getElementById("photo-counter").innerHTML = (idx + 1) + " / " + photos.length;
   loadExifOverlay(filename);
+  updateWasteBadge();
 }
 
 function loadExifOverlay(filename) {
@@ -1670,10 +2429,19 @@ function loadExifOverlay(filename) {
 function advanceTick() {
   if (weatherModeActive && weatherData && photosSinceWeather >= WEATHER_INTERVAL) {
     photosSinceWeather = 0;
+    photosSinceWaste++;
     showWeatherSlide();
     return;
   }
+  if (wasteModeHas("slide") && currentWasteAlert() &&
+      photosSinceWaste >= (wasteCfg.photo_interval || 10)) {
+    photosSinceWaste = 0;
+    photosSinceWeather++;
+    showWasteSlide();
+    return;
+  }
   photosSinceWeather++;
+  photosSinceWaste++;
   currentIndex = (currentIndex + 1) % photos.length;
   showPhoto(currentIndex);
 }
@@ -1738,6 +2506,7 @@ function showWeatherSlide() {
   document.getElementById("overlay-date").innerHTML     = "";
   document.getElementById("overlay-location").innerHTML = "";
   document.getElementById("photo-counter").innerHTML    = "";
+  document.getElementById("waste-badge").className      = "";
   document.getElementById("weather-slide").className = "visible";
 }
 
@@ -1774,6 +2543,562 @@ function renderHourly(hourly) {
 
 function hideWeatherSlide() {
   document.getElementById("weather-slide").className = "";
+}
+
+// ── Kalendár vývozu odpadu: beh na fotorámiku ─────────────────────────────────
+var wasteCfg          = null;   // nastavenia zo /waste/status
+var wasteByDate       = {};     // "YYYY-MM-DD" -> [{id,label,icon,color}, ...]
+var wasteUpcoming     = [];     // surový zoznam pre náhľad v editore
+var photosSinceWaste  = 0;
+var wasteSlideVisible = false;
+
+function _pad2(n) { return (n < 10 ? "0" : "") + n; }
+
+// Lokálny ISO dátum (NIE toISOString – ten prepočíta na UTC a v CEST posunie deň).
+function _isoLocal(d) {
+  return d.getFullYear() + "-" + _pad2(d.getMonth() + 1) + "-" + _pad2(d.getDate());
+}
+
+function fetchWasteStatus() {
+  xhrGet("/waste/status", function(err, text) {
+    if (err) { return; }
+    try {
+      var data = JSON.parse(text);
+      wasteCfg      = data;
+      wasteUpcoming = data.upcoming || [];
+      wasteByDate   = {};
+      for (var i = 0; i < wasteUpcoming.length; i++) {
+        wasteByDate[wasteUpcoming[i].date] = wasteUpcoming[i].types || [];
+      }
+    } catch (e) { return; }
+    updateWasteBadge();
+  });
+}
+setInterval(fetchWasteStatus, 15 * 60 * 1000);
+
+// Ktorý najbližší termín (v rámci nastaveného predstihu) máme práve pripomínať.
+// „Dnešok“ určuje prehliadač na tablete – ten má správnu lokálnu časovú zónu.
+function currentWasteAlert() {
+  if (!wasteCfg || !wasteCfg.enabled) { return null; }
+  var now   = new Date();
+  var start = wasteCfg.show_on_day ? 0 : 1;
+  for (var off = start; off <= wasteCfg.days_before; off++) {
+    var d     = new Date(now.getFullYear(), now.getMonth(), now.getDate() + off);
+    var types = wasteByDate[_isoLocal(d)];
+    if (!types || !types.length) { continue; }
+    // deň-vopred pripomienku netlačiť skôr, než si používateľ praje
+    if (off >= 1 && now.getHours() < (wasteCfg.start_hour || 0)) { continue; }
+    return { days: off, date: _isoLocal(d), types: types };
+  }
+  return null;
+}
+
+function wasteModeHas(what) {
+  if (!wasteCfg) { return false; }
+  return wasteCfg.mode === what || wasteCfg.mode === "both";
+}
+
+function wasteWhenLabel(days) {
+  if (days === 0) { return tr("waste_today"); }
+  if (days === 1) { return tr("waste_tomorrow"); }
+  if (days <= 4)  { return trf("waste_in_days_few",  [days]); }
+  return trf("waste_in_days_many", [days]);
+}
+
+function wasteIcons(types) {
+  var out = "";
+  for (var i = 0; i < types.length; i++) { out += types[i].icon; }
+  return out;
+}
+
+function wasteNames(types) {
+  var out = [];
+  for (var i = 0; i < types.length; i++) { out.push(types[i].label); }
+  return out;
+}
+
+function _wasteFormatDate(iso) {
+  var p = iso.split("-");
+  var d = new Date(parseInt(p[0], 10), parseInt(p[1], 10) - 1, parseInt(p[2], 10));
+  return WEEKDAYS[(d.getDay() + 6) % 7] + " · " + d.toLocaleDateString();
+}
+
+function updateWasteBadge() {
+  var el = document.getElementById("waste-badge");
+  if (!el) { return; }
+  var a = currentWasteAlert();
+  if (!a || !wasteModeHas("overlay") || !slideshowActive ||
+      wasteSlideVisible || _weatherIsVisible() || _sleeping) {
+    el.className = ""; return;
+  }
+  document.getElementById("waste-badge-ico").innerHTML  = escHtml(wasteIcons(a.types));
+  document.getElementById("waste-badge-when").innerHTML = escHtml(wasteWhenLabel(a.days));
+  document.getElementById("waste-badge-what").innerHTML = escHtml(wasteNames(a.types).join(" · "));
+  el.style.borderLeftColor = a.types[0].color || "#9aa5b1";
+  el.className = "visible";
+}
+
+function showWasteSlide() {
+  var a = currentWasteAlert();
+  if (!a) { return; }
+  var names = wasteNames(a.types), html = "";
+  for (var i = 0; i < names.length; i++) {
+    if (i) { html += "<span class=\"wn-sep\"> · </span>"; }
+    html += escHtml(names[i]);
+  }
+  document.getElementById("waste-slide-icons").innerHTML = escHtml(wasteIcons(a.types));
+  document.getElementById("waste-slide-when").innerHTML  =
+      escHtml(wasteWhenLabel(a.days) + " · " + tr("waste_headline"));
+  document.getElementById("waste-slide-names").innerHTML = html;
+  document.getElementById("waste-slide-accent").style.background = a.types[0].color || "#7cb342";
+  document.getElementById("waste-slide-hint").innerHTML  =
+      escHtml(a.days === 0 ? tr("waste_hint_today") : tr("waste_hint"));
+  document.getElementById("waste-slide-date").innerHTML  = escHtml(_wasteFormatDate(a.date));
+  document.getElementById("overlay-date").innerHTML     = "";
+  document.getElementById("overlay-location").innerHTML = "";
+  document.getElementById("photo-counter").innerHTML    = "";
+  document.getElementById("waste-badge").className      = "";
+  document.getElementById("waste-slide").className      = "visible";
+  wasteSlideVisible = true;
+}
+
+function hideWasteSlide() {
+  document.getElementById("waste-slide").className = "";
+  wasteSlideVisible = false;
+}
+
+// ── Kalendár vývozu odpadu: editor ───────────────────────────────────────────
+var wdCfg      = null;   // pracovná kópia celého configu
+var wdTypes    = [];     // katalóg druhov odpadu zo servera
+var wdMaxRules = 40;
+var wdRule     = null;   // pracovná kópia práve editovaného pravidla
+var wdRuleIdx  = -1;     // index v wdCfg.rules, -1 = nové pravidlo
+
+function openWasteDialog() {
+  closeSettings();
+  document.getElementById("waste-dialog").style.display = "block";
+  document.getElementById("waste-main").style.display   = "block";
+  document.getElementById("waste-editor").style.display = "none";
+  document.getElementById("waste-dialog").scrollTop     = 0;
+  wdStatus("", "");
+  xhrGet("/waste/config", function(err, text) {
+    if (err) { wdStatus(tr("waste_save_err"), "err"); return; }
+    try {
+      var data   = JSON.parse(text);
+      wdCfg      = data.config || {};
+      wdTypes    = data.types  || [];
+      wdMaxRules = data.max_rules || 40;
+    } catch (e) { wdStatus(tr("waste_save_err"), "err"); return; }
+    if (!wdCfg.rules) { wdCfg.rules = []; }
+    wdRenderMain();
+  });
+}
+
+function closeWasteDialog() {
+  document.getElementById("waste-dialog").style.display = "none";
+  fetchWasteStatus();
+}
+
+function wdStatus(msg, cls) {
+  var el = document.getElementById("waste-status");
+  el.innerHTML = escHtml(msg || "");
+  el.className = "wd-status" + (cls ? " " + cls : "");
+}
+
+function _seg(id, active) {
+  var el = document.getElementById(id);
+  if (el) { el.className = "wd-opt" + (active ? " active" : ""); }
+}
+
+function wdSetEnabled(on) { wdCfg.enabled = !!on; wdRenderMain(); }
+function wdSetMode(m)     { wdCfg.mode = m;      wdRenderMain(); }
+
+function wdStep(key, delta, lo, hi) {
+  var v = (parseInt(wdCfg[key], 10) || 0) + delta;
+  if (v < lo) { v = lo; }
+  if (v > hi) { v = hi; }
+  wdCfg[key] = v;
+  if (key === "days_before" && v === 0) { wdCfg.show_on_day = true; }
+  wdRenderMain();
+}
+
+function wdToggleShowOnDay() {
+  if (wdCfg.days_before === 0) { return; }   // inak by sa nezobrazilo nikdy nič
+  wdCfg.show_on_day = !wdCfg.show_on_day;
+  wdRenderMain();
+}
+
+function wdRenderMain() {
+  _seg("waste-en-on",  wdCfg.enabled);
+  _seg("waste-en-off", !wdCfg.enabled);
+  _seg("waste-mode-overlay", wdCfg.mode === "overlay");
+  _seg("waste-mode-slide",   wdCfg.mode === "slide");
+  _seg("waste-mode-both",    wdCfg.mode === "both");
+  document.getElementById("waste-interval-group").style.display =
+      (wdCfg.mode === "overlay") ? "none" : "";
+  document.getElementById("waste-interval-val").innerHTML = wdCfg.photo_interval;
+  document.getElementById("waste-days-val").innerHTML     = wdCfg.days_before;
+  document.getElementById("waste-hour-val").innerHTML     = _pad2(wdCfg.start_hour) + ":00";
+  document.getElementById("waste-showday-check").className =
+      "wd-check" + (wdCfg.show_on_day ? " on" : "");
+  wdRenderRules();
+  wdRenderPreview();
+}
+
+function wdTypeInfo(id) {
+  for (var i = 0; i < wdTypes.length; i++) {
+    if (wdTypes[i].id === id) { return wdTypes[i]; }
+  }
+  return { id: id, label: id, icon: "♻️", color: "#9aa5b1" };
+}
+
+// Slovenčina skloňuje 1 / 2–4 / 5+ inak; ostatné jazyky použijú rovnaký tvar.
+function wdCountLabel(n) {
+  if (n === 1)              { return trf("waste_dates_one",  [n]); }
+  if (n >= 2 && n <= 4)     { return trf("waste_dates_few",  [n]); }
+  return trf("waste_dates_many", [n]);
+}
+
+function wdRuleSummary(rule) {
+  var rec = rule.recurrence || {}, out = "";
+  if (rec.kind === "weekly") {
+    var n = rec.interval_weeks || 1;
+    out = WEEKDAYS[rec.weekday || 0] + " · " +
+          (n === 1 ? tr("waste_every_week") : trf("waste_every_n_weeks", [n]));
+  } else if (rec.kind === "monthly") {
+    if (rec.monthly_by === "day") {
+      out = tr("waste_day_of_month") + ": " + (rec.day_of_month || 1) + ".";
+    } else {
+      out = WEEK_ORDINALS["" + (rec.week_of_month || 1)] + " " +
+            WEEKDAYS[rec.weekday || 0].toLowerCase();
+    }
+    if (rec.months && rec.months.length) {
+      var mm = [];
+      for (var i = 0; i < rec.months.length; i++) { mm.push(MONTHS_LIST[rec.months[i] - 1].substr(0, 3)); }
+      out += " (" + mm.join(", ") + ")";
+    }
+  } else {
+    out = wdCountLabel((rec.dates || []).length);
+  }
+  if ((rule.extra || []).length) { out += " +" + rule.extra.length; }
+  if ((rule.skip  || []).length) { out += " −" + rule.skip.length; }
+  return out;
+}
+
+function wdRenderRules() {
+  var host = document.getElementById("waste-rule-list");
+  var rules = wdCfg.rules || [];
+  if (!rules.length) {
+    host.innerHTML = "<div class=\"wd-empty\">" + escHtml(tr("waste_no_rules")) + "</div>";
+  } else {
+    var html = "";
+    for (var i = 0; i < rules.length; i++) {
+      var info = wdTypeInfo(rules[i].type);
+      var name = rules[i].label || info.label;
+      html += "<div class=\"wd-rule\" style=\"border-left-color:" + escHtml(info.color) + "\""
+            + " onclick=\"wdEditRule(" + i + ")\">"
+            + "<div class=\"wr-ico\">" + escHtml(info.icon) + "</div>"
+            + "<div class=\"wr-txt\"><div class=\"wr-name\">" + escHtml(name) + "</div>"
+            + "<div class=\"wr-sub\">" + escHtml(wdRuleSummary(rules[i])) + "</div></div>"
+            + "<div class=\"wr-go\">&#8250;</div></div>";
+    }
+    host.innerHTML = html;
+  }
+  var addBtn = document.getElementById("t-waste-add-rule");
+  addBtn.style.display = (rules.length >= wdMaxRules) ? "none" : "";
+}
+
+// Náhľad ukazuje ULOŽENÝ harmonogram (rozvinutý serverom), nie rozpracované zmeny.
+function wdRenderPreview() {
+  var host = document.getElementById("waste-preview-list");
+  if (!wasteUpcoming.length) {
+    host.innerHTML = "<div class=\"wd-empty\">" + escHtml(tr("waste_preview_none")) + "</div>";
+    return;
+  }
+  var todayIso = _isoLocal(new Date()), html = "", shown = 0;
+  for (var i = 0; i < wasteUpcoming.length && shown < 6; i++) {
+    if (wasteUpcoming[i].date < todayIso) { continue; }
+    shown++;
+    html += "<div class=\"wd-preview-day\"><div class=\"wp-date\">"
+          + escHtml(_wasteFormatDate(wasteUpcoming[i].date)) + "</div>"
+          + "<div class=\"wp-types\">"
+          + escHtml(wasteIcons(wasteUpcoming[i].types) + " " +
+                    wasteNames(wasteUpcoming[i].types).join(", "))
+          + "</div></div>";
+  }
+  host.innerHTML = shown ? html
+      : "<div class=\"wd-empty\">" + escHtml(tr("waste_preview_none")) + "</div>";
+}
+
+function wdSaveConfig() {
+  wdStatus("…", "");
+  var xhr = new XMLHttpRequest();
+  xhr.open("POST", "/waste/config", true);
+  xhr.setRequestHeader("Content-Type", "application/json");
+  xhr.onreadystatechange = function() {
+    if (xhr.readyState !== 4) { return; }
+    if (xhr.status !== 200) { wdStatus(tr("waste_save_err"), "err"); return; }
+    try {
+      var data = JSON.parse(xhr.responseText);
+      if (data.config) { wdCfg = data.config; if (!wdCfg.rules) { wdCfg.rules = []; } }
+    } catch (e) {}
+    wdStatus(tr("waste_saved"), "ok");
+    // po uložení si vypýtaj rozvinutý harmonogram, nech sedí náhľad aj rámik
+    xhrGet("/waste/status", function(err2, text2) {
+      if (!err2) {
+        try {
+          var st = JSON.parse(text2);
+          wasteCfg      = st;
+          wasteUpcoming = st.upcoming || [];
+          wasteByDate   = {};
+          for (var i = 0; i < wasteUpcoming.length; i++) {
+            wasteByDate[wasteUpcoming[i].date] = wasteUpcoming[i].types || [];
+          }
+        } catch (e2) {}
+      }
+      updateWasteBadge();
+      wdRenderMain();
+    });
+  };
+  xhr.send(JSON.stringify(wdCfg));
+}
+
+// ── Editor jedného zvozu ─────────────────────────────────────────────────────
+function _newRuleId() {
+  return "r" + Date.now().toString(36) + Math.floor(Math.random() * 1000).toString(36);
+}
+
+function wdNewRule() {
+  wdRuleIdx = -1;
+  wdRule = {
+    id: _newRuleId(), type: (wdTypes[0] ? wdTypes[0].id : "mixed"), label: "",
+    recurrence: { kind: "weekly", weekday: 0, interval_weeks: 1, anchor: "", months: [] },
+    from: "", to: "", skip: [], extra: []
+  };
+  wdOpenEditor();
+}
+
+function wdEditRule(idx) {
+  wdRuleIdx = idx;
+  var src = wdCfg.rules[idx];
+  var rec = src.recurrence || {};
+  wdRule = {
+    id: src.id || _newRuleId(), type: src.type, label: src.label || "",
+    recurrence: {
+      kind:           rec.kind || "weekly",
+      weekday:        rec.weekday || 0,
+      interval_weeks: rec.interval_weeks || 1,
+      anchor:         rec.anchor || "",
+      week_of_month:  rec.week_of_month || 1,
+      day_of_month:   rec.day_of_month || 1,
+      monthly_by:     rec.monthly_by || "weekday",
+      months:         (rec.months || []).slice(0),
+      dates:          (rec.dates  || []).slice(0)
+    },
+    from: src.from || "", to: src.to || "",
+    skip: (src.skip || []).slice(0), extra: (src.extra || []).slice(0)
+  };
+  wdOpenEditor();
+}
+
+function wdOpenEditor() {
+  document.getElementById("waste-main").style.display   = "none";
+  document.getElementById("waste-editor").style.display = "block";
+  document.getElementById("waste-dialog").scrollTop     = 0;
+  document.getElementById("t-waste-rule-delete").style.display = (wdRuleIdx < 0) ? "none" : "";
+  document.getElementById("waste-name-input").value  = wdRule.label || "";
+  document.getElementById("waste-from-input").value  = wdRule.from  || "";
+  document.getElementById("waste-to-input").value    = wdRule.to    || "";
+  document.getElementById("waste-anchor-input").value = wdRule.recurrence.anchor || "";
+  wdBuildTypeSeg();
+  wdBuildWeekdaySegs();
+  wdBuildWomSelect();
+  wdBuildMonthChips();
+  wdRenderEditor();
+}
+
+function wdBuildTypeSeg() {
+  var host = document.getElementById("waste-type-seg"), html = "";
+  for (var i = 0; i < wdTypes.length; i++) {
+    var t = wdTypes[i];
+    html += "<div class=\"wd-opt\" id=\"wd-type-" + escHtml(t.id) + "\""
+          + " onclick=\"wdSetType('" + escHtml(t.id) + "')\">"
+          + "<div style=\"font-size:24px;line-height:1.2\">" + escHtml(t.icon) + "</div>"
+          + "<div style=\"font-size:11px;margin-top:3px\">" + escHtml(t.label) + "</div></div>";
+  }
+  host.innerHTML = html;
+}
+
+function wdBuildWeekdaySegs() {
+  var html = "";
+  for (var i = 0; i < 7; i++) {
+    html += "<div class=\"wd-opt\" id=\"__PFX__" + i + "\" onclick=\"wdSetWeekday(" + i + ")\">"
+          + escHtml(WEEKDAYS_SHORT[i]) + "</div>";
+  }
+  document.getElementById("waste-weekday-seg").innerHTML  = html.replace(/__PFX__/g, "wd-wd-");
+  document.getElementById("waste-weekday-seg2").innerHTML = html.replace(/__PFX__/g, "wd-wd2-");
+}
+
+function wdBuildWomSelect() {
+  var sel = document.getElementById("waste-wom-select"), html = "";
+  var order = ["1", "2", "3", "4", "5", "-1"];
+  for (var i = 0; i < order.length; i++) {
+    html += "<option value=\"" + order[i] + "\">" + escHtml(WEEK_ORDINALS[order[i]]) + "</option>";
+  }
+  sel.innerHTML = html;
+}
+
+function wdBuildMonthChips() {
+  var host = document.getElementById("waste-months-chips"), html = "";
+  for (var m = 1; m <= 12; m++) {
+    html += "<div class=\"wd-chip month\" id=\"wd-month-" + m + "\" onclick=\"wdToggleMonth(" + m + ")\">"
+          + escHtml(MONTHS_LIST[m - 1].substr(0, 3)) + "</div>";
+  }
+  host.innerHTML = html;
+}
+
+function wdSetType(id)  { wdRule.type = id; wdRenderEditor(); }
+function wdSetKind(k)   { wdRule.recurrence.kind = k; wdRenderEditor(); }
+function wdSetWeekday(i){ wdRule.recurrence.weekday = i; wdRenderEditor(); }
+function wdSetMonthlyBy(v) { wdRule.recurrence.monthly_by = v; wdRenderEditor(); }
+function wdReadWom()    { wdRule.recurrence.week_of_month = parseInt(document.getElementById("waste-wom-select").value, 10); }
+function wdReadAnchor() { wdRule.recurrence.anchor = _wdCleanDate(document.getElementById("waste-anchor-input").value); }
+function wdReadRange()  {
+  wdRule.from = _wdCleanDate(document.getElementById("waste-from-input").value);
+  wdRule.to   = _wdCleanDate(document.getElementById("waste-to-input").value);
+}
+
+function wdStepRule(key, delta, lo, hi) {
+  var v = (parseInt(wdRule.recurrence[key], 10) || 0) + delta;
+  if (v < lo) { v = lo; }
+  if (v > hi) { v = hi; }
+  wdRule.recurrence[key] = v;
+  wdRenderEditor();
+}
+
+function wdToggleMonth(m) {
+  var arr = wdRule.recurrence.months || [], idx = -1;
+  for (var i = 0; i < arr.length; i++) { if (arr[i] === m) { idx = i; break; } }
+  if (idx >= 0) { arr.splice(idx, 1); } else { arr.push(m); arr.sort(function(a, b) { return a - b; }); }
+  wdRule.recurrence.months = arr;
+  wdRenderEditor();
+}
+
+function _wdCleanDate(v) {
+  v = (v || "").replace(/^\s+|\s+$/g, "");
+  return /^\d{4}-\d{2}-\d{2}$/.test(v) ? v : "";
+}
+
+function _wdListFor(which) {
+  return (which === "dates") ? (wdRule.recurrence.dates = wdRule.recurrence.dates || [])
+       : (which === "skip")  ? (wdRule.skip  = wdRule.skip  || [])
+                             : (wdRule.extra = wdRule.extra || []);
+}
+
+function wdAddDate(which) {
+  var input = document.getElementById("waste-" + (which === "dates" ? "date" : which) + "-input");
+  var v = _wdCleanDate(input.value);
+  if (!v) { return; }
+  var list = _wdListFor(which);
+  for (var i = 0; i < list.length; i++) { if (list[i] === v) { input.value = ""; return; } }
+  list.push(v);
+  list.sort();
+  input.value = "";
+  wdRenderEditor();
+}
+
+function wdRemoveDate(which, iso) {
+  var list = _wdListFor(which);
+  for (var i = 0; i < list.length; i++) {
+    if (list[i] === iso) { list.splice(i, 1); break; }
+  }
+  wdRenderEditor();
+}
+
+function _wdRenderChips(hostId, which, list) {
+  var host = document.getElementById(hostId), html = "";
+  for (var i = 0; i < list.length; i++) {
+    html += "<div class=\"wd-chip\" onclick=\"wdRemoveDate('" + which + "','" + escHtml(list[i]) + "')\">"
+          + escHtml(list[i]) + "<span class=\"wc-x\">&times;</span></div>";
+  }
+  host.innerHTML = html;
+}
+
+function wdRenderEditor() {
+  var rec = wdRule.recurrence;
+  for (var i = 0; i < wdTypes.length; i++) {
+    _seg("wd-type-" + wdTypes[i].id, wdTypes[i].id === wdRule.type);
+  }
+  _seg("waste-kind-weekly",  rec.kind === "weekly");
+  _seg("waste-kind-monthly", rec.kind === "monthly");
+  _seg("waste-kind-dates",   rec.kind === "dates");
+  document.getElementById("waste-weekly-box").style.display  = (rec.kind === "weekly")  ? "" : "none";
+  document.getElementById("waste-monthly-box").style.display = (rec.kind === "monthly") ? "" : "none";
+  document.getElementById("waste-dates-box").style.display   = (rec.kind === "dates")   ? "" : "none";
+
+  for (var w = 0; w < 7; w++) {
+    _seg("wd-wd-"  + w, w === rec.weekday);
+    _seg("wd-wd2-" + w, w === rec.weekday);
+  }
+  document.getElementById("waste-weeks-val").innerHTML = rec.interval_weeks || 1;
+  document.getElementById("waste-anchor-group").style.display = ((rec.interval_weeks || 1) > 1) ? "" : "none";
+
+  _seg("waste-by-weekday", rec.monthly_by !== "day");
+  _seg("waste-by-day",     rec.monthly_by === "day");
+  document.getElementById("waste-by-weekday-box").style.display = (rec.monthly_by === "day") ? "none" : "";
+  document.getElementById("waste-by-day-box").style.display     = (rec.monthly_by === "day") ? "" : "none";
+  document.getElementById("waste-wom-select").value = "" + (rec.week_of_month || 1);
+  document.getElementById("waste-dom-val").innerHTML = rec.day_of_month || 1;
+
+  var months = rec.months || [];
+  for (var m = 1; m <= 12; m++) {
+    var on = false;
+    for (var k = 0; k < months.length; k++) { if (months[k] === m) { on = true; break; } }
+    var chip = document.getElementById("wd-month-" + m);
+    if (chip) { chip.className = "wd-chip month" + (on ? " on" : ""); }
+  }
+
+  _wdRenderChips("waste-dates-chips", "dates", rec.dates || []);
+  _wdRenderChips("waste-skip-chips",  "skip",  wdRule.skip  || []);
+  _wdRenderChips("waste-extra-chips", "extra", wdRule.extra || []);
+}
+
+function wdCommitRule() {
+  var rec = wdRule.recurrence;
+  wdRule.label = document.getElementById("waste-name-input").value.replace(/^\s+|\s+$/g, "");
+  wdReadRange();
+  if (rec.kind === "weekly") {
+    wdReadAnchor();
+    // bez referenčného dátumu sa fáza „každý N-tý týždeň“ nedá určiť
+    if ((rec.interval_weeks || 1) > 1 && !rec.anchor) {
+      document.getElementById("waste-anchor-input").focus();
+      return;
+    }
+  } else if (rec.kind === "dates") {
+    if (!(rec.dates || []).length && !(wdRule.extra || []).length) {
+      document.getElementById("waste-date-input").focus();
+      return;
+    }
+  }
+  if (wdRuleIdx < 0) { wdCfg.rules.push(wdRule); }
+  else               { wdCfg.rules[wdRuleIdx] = wdRule; }
+  wdCloseEditor();
+}
+
+function wdCancelRule() { wdCloseEditor(); }
+
+function wdDeleteRule() {
+  if (wdRuleIdx >= 0) { wdCfg.rules.splice(wdRuleIdx, 1); }
+  wdCloseEditor();
+}
+
+function wdCloseEditor() {
+  wdRule = null; wdRuleIdx = -1;
+  document.getElementById("waste-editor").style.display = "none";
+  document.getElementById("waste-main").style.display   = "block";
+  document.getElementById("waste-dialog").scrollTop     = 0;
+  wdStatus("", "");
+  wdRenderMain();
 }
 
 // ── Swipe + dlhý tap ──────────────────────────────────────────────────────────
@@ -1944,6 +3269,7 @@ applyTranslations();
 checkSleep();
 loadAlbums();
 fetchWeatherStatus();
+fetchWasteStatus();
 </script>
 </body>
 </html>"""
@@ -1953,6 +3279,10 @@ fetchWeatherStatus();
     html = html.replace("__SLEEP_START__",    SLEEP_START)
     html = html.replace("__SLEEP_END__",      SLEEP_END)
     html = html.replace("__WEATHER_INTERVAL__", str(WEATHER_PHOTO_INTERVAL))
+    html = html.replace("__WEEKDAYS__",       json_module.dumps(WEEKDAYS[lang], ensure_ascii=False))
+    html = html.replace("__WEEKDAYS_SHORT__", json_module.dumps(WEEKDAYS_SHORT[lang], ensure_ascii=False))
+    html = html.replace("__MONTHS_LIST__",    json_module.dumps(MONTHS[lang], ensure_ascii=False))
+    html = html.replace("__WEEK_ORDINALS__",  json_module.dumps(WEEK_ORDINALS[lang], ensure_ascii=False))
     resp = Response(html, mimetype="text/html; charset=utf-8")
     # Nekešuj HTML (obsahuje všetok CSS/JS) – nástenný displej tak vždy dostane
     # aktuálnu verziu po update/rebuild bez ručného čistenia cache v Safari.

--- a/snapframe/rootfs/usr/bin/webserver.py
+++ b/snapframe/rootfs/usr/bin/webserver.py
@@ -55,6 +55,7 @@ SLEEP_START     = _env_str("SLEEP_START", "")         # "23:00" alebo ""
 SLEEP_END       = _env_str("SLEEP_END",   "")         # "07:00" alebo ""
 WEATHER_PHOTO_INTERVAL   = _env_int("WEATHER_PHOTO_INTERVAL", 8)      # fotiek medzi weather slidmi
 WEATHER_MODE_DURATION_MIN = _env_int("WEATHER_MODE_DURATION_MIN", 120)  # min trvania po /weather-mode/on
+ANTHROPIC_API_KEY = _env_str("ANTHROPIC_API_KEY")   # nepovinné – záloha pre skeny/fotky harmonogramu
 
 GEOCACHE_FILE = "/data/geocode_cache.json"
 ALLOWED_EXT   = (".jpg", ".jpeg", ".png")
@@ -67,6 +68,12 @@ try:
     _has_state = True
 except ImportError:
     _has_state = False
+
+try:
+    import waste_import as _waste_import
+    _has_waste_import = True
+except ImportError:               # pragma: no cover
+    _has_waste_import = False
 
 try:
     import waste as _waste
@@ -199,6 +206,25 @@ TRANSLATIONS = {
         "waste_dates_one":      "{0} dátum",
         "waste_dates_few":      "{0} dátumy",
         "waste_dates_many":     "{0} dátumov",
+        # — Import harmonogramu —
+        "wimp_open":            "\u2191 Načítať z harmonogramu…",
+        "wimp_title":           "Import harmonogramu",
+        "wimp_intro":           "Nahraj PDF alebo fotku obecného rozpisu vývozu. Nič sa neuloží, kým nepotvrdíš.",
+        "wimp_pick":            "Vybrať súbor…",
+        "wimp_working":         "Spracúvam harmonogram…",
+        "wimp_found":           "Nájdené rady vývozov ({0}) · rok {1}",
+        "wimp_hint":            "Leták obce často obsahuje viac rozpisov naraz (napr. dvojtýždňový aj mesačný zvoz). Zaškrtni len tie, ktoré platia pre teba.",
+        "wimp_use":             "Použiť",
+        "wimp_add":             "Pridať vybraté zvozy",
+        "wimp_none_selected":   "Vyber aspoň jeden rad.",
+        "wimp_added":           "✓ Pridané: {0} zvozov",
+        "wimp_err_format":      "Nepodporovaný formát. Nahraj PDF, JPG alebo PNG.",
+        "wimp_err_large":       "Súbor je príliš veľký (max 12 MB).",
+        "wimp_err_parse":       "V súbore sa nepodarilo nájsť kalendár vývozov.",
+        "wimp_err_novision":    "Toto rozloženie parser nepozná. Rozpoznanie z fotky vieš zapnúť doplnením Anthropic API kľúča v konfigurácii add-onu.",
+        "wimp_err_generic":     "Import zlyhal.",
+        "wimp_via_pdf":         "načítané priamo z PDF",
+        "wimp_via_vision":      "rozpoznané z obrázka",
     },
     "en": {
         "app_title":            "SnapFrame",
@@ -297,6 +323,25 @@ TRANSLATIONS = {
         "waste_dates_one":      "{0} date",
         "waste_dates_few":      "{0} dates",
         "waste_dates_many":     "{0} dates",
+        # — Schedule import —
+        "wimp_open":            "\u2191 Import from schedule…",
+        "wimp_title":           "Import schedule",
+        "wimp_intro":           "Upload the PDF or a photo of your municipal collection schedule. Nothing is saved until you confirm.",
+        "wimp_pick":            "Choose file…",
+        "wimp_working":         "Reading the schedule…",
+        "wimp_found":           "Collection series found ({0}) · year {1}",
+        "wimp_hint":            "Municipal leaflets often hold several schedules at once (e.g. a fortnightly and a monthly round). Tick only the ones that apply to you.",
+        "wimp_use":             "Use",
+        "wimp_add":             "Add selected collections",
+        "wimp_none_selected":   "Select at least one series.",
+        "wimp_added":           "✓ Added: {0} collections",
+        "wimp_err_format":      "Unsupported format. Upload a PDF, JPG or PNG.",
+        "wimp_err_large":       "File is too large (max 12 MB).",
+        "wimp_err_parse":       "No collection calendar could be found in this file.",
+        "wimp_err_novision":    "This layout isn't recognised by the parser. To enable reading from photos, add an Anthropic API key in the add-on configuration.",
+        "wimp_err_generic":     "Import failed.",
+        "wimp_via_pdf":         "read straight from the PDF",
+        "wimp_via_vision":      "recognised from the image",
     },
     "de": {
         "app_title":            "SnapFrame",
@@ -395,6 +440,25 @@ TRANSLATIONS = {
         "waste_dates_one":      "{0} Termin",
         "waste_dates_few":      "{0} Termine",
         "waste_dates_many":     "{0} Termine",
+        # — Kalenderimport —
+        "wimp_open":            "\u2191 Aus Abfuhrkalender laden…",
+        "wimp_title":           "Kalender importieren",
+        "wimp_intro":           "Lade das PDF oder ein Foto des kommunalen Abfuhrkalenders hoch. Es wird nichts gespeichert, bis du bestätigst.",
+        "wimp_pick":            "Datei wählen…",
+        "wimp_working":         "Kalender wird gelesen…",
+        "wimp_found":           "Gefundene Abfuhrreihen ({0}) · Jahr {1}",
+        "wimp_hint":            "Kommunale Faltblätter enthalten oft mehrere Kalender gleichzeitig (z. B. 14-tägig und monatlich). Kreuze nur die an, die für dich gelten.",
+        "wimp_use":             "Verwenden",
+        "wimp_add":             "Ausgewählte Abfuhren hinzufügen",
+        "wimp_none_selected":   "Wähle mindestens eine Reihe.",
+        "wimp_added":           "✓ Hinzugefügt: {0} Abfuhren",
+        "wimp_err_format":      "Format nicht unterstützt. Lade ein PDF, JPG oder PNG hoch.",
+        "wimp_err_large":       "Datei ist zu groß (max. 12 MB).",
+        "wimp_err_parse":       "In dieser Datei wurde kein Abfuhrkalender gefunden.",
+        "wimp_err_novision":    "Dieses Layout kennt der Parser nicht. Für die Erkennung aus Fotos trage einen Anthropic-API-Schlüssel in der Add-on-Konfiguration ein.",
+        "wimp_err_generic":     "Import fehlgeschlagen.",
+        "wimp_via_pdf":         "direkt aus dem PDF gelesen",
+        "wimp_via_vision":      "aus dem Bild erkannt",
     },
 }
 
@@ -1008,6 +1072,50 @@ def waste_next_route():
         "text":       ", ".join(labels),
     })
 
+@app.route("/waste/import", methods=["POST"])
+def waste_import_route():
+    """Vytiahni termíny z nahratého harmonogramu. Nič neukladá – iba vráti návrh.
+
+    Rozpoznanie sa NIKDY neuloží automaticky: zle prečítaný termín znamená
+    zmeškaný kontajner, čo je práve to, čomu má celá funkcia zabrániť.
+    Používateľ preto najprv v appke potvrdí, ktoré rady sa ho týkajú.
+    """
+    if not _has_waste_import:
+        return jsonify({"ok": False, "error": "unavailable"}), 503
+    f = request.files.get("file")
+    if not f or not f.filename:
+        return jsonify({"ok": False, "error": "no file"}), 400
+    data = f.read(_waste_import.MAX_UPLOAD_BYTES + 1)
+    if len(data) > _waste_import.MAX_UPLOAD_BYTES:
+        return jsonify({"ok": False, "error": "too_large"}), 413
+    if not data:
+        return jsonify({"ok": False, "error": "empty"}), 400
+
+    ext  = Path(_safe_filename(f.filename)).suffix.lower()
+    lang = _waste_lang()
+    is_pdf = ext == ".pdf" or data[:5] == b"%PDF-"
+
+    result = _waste_import.parse_pdf(data, lang) if is_pdf else {"ok": False, "error": "not_pdf"}
+    if not result.get("ok"):
+        # Fotka, sken alebo neznáme rozloženie – skús vision model, ak je kľúč.
+        media = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+                 ".webp": "image/webp", ".gif": "image/gif",
+                 ".pdf": "application/pdf"}.get(ext, "application/pdf" if is_pdf else "")
+        if not media:
+            return jsonify({"ok": False, "error": "unsupported_format"}), 400
+        if not ANTHROPIC_API_KEY:
+            return jsonify({"ok": False, "error": result.get("error") or "no_api_key",
+                            "vision_available": False}), 422
+        log.info("Harmonogram: parser neuspel ({}), skúšam vision".format(result.get("error")))
+        result = _waste_import.parse_with_vision(data, media, lang, ANTHROPIC_API_KEY)
+        if not result.get("ok"):
+            return jsonify(result), 422
+
+    log.info("Harmonogram naimportovaný ({}): {} radov, rok {}".format(
+        result.get("source"), len(result.get("series", [])), result.get("year")))
+    result["types"] = _waste.type_catalog(lang) if _has_waste else []
+    return jsonify(result)
+
 # ── HTML ──────────────────────────────────────────────────────────────────────
 
 @app.route("/")
@@ -1420,6 +1528,39 @@ html, body {
   .waste-hint  { font-size: 20px; font-size: clamp(15px, 4vw, 26px); }
   .waste-date  { position: static; margin-top: 26px; }
 }
+/* ===== ODPAD: import harmonogramu ===== */
+.wimp-intro { font-size: 12px; line-height: 1.55; color: #6a6a6a; margin-bottom: 12px; }
+.wimp-hint  { font-size: 11px; line-height: 1.55; color: #4a4a4a; margin: 8px 0 12px; }
+#waste-import-file { display: none; }
+.wimp-serie {
+  display: table; width: 100%; background: #151515; border: 1px solid #232323;
+  border-radius: 11px; padding: 12px 13px; margin-bottom: 8px;
+  -webkit-box-sizing: border-box; box-sizing: border-box;
+  cursor: pointer; -webkit-tap-highlight-color: transparent;
+}
+.wimp-serie.on { border-color: #4a7fd6; background: #171e2b; }
+.wimp-serie .ws-sw {
+  display: table-cell; vertical-align: middle; width: 34px;
+}
+.wimp-serie .ws-chip {
+  width: 22px; height: 22px; border-radius: 6px;
+  border: 3px solid transparent; -webkit-box-sizing: border-box; box-sizing: border-box;
+}
+.wimp-serie .ws-txt { display: table-cell; vertical-align: middle; padding-right: 8px; }
+.wimp-serie .ws-name { color: #e8e8e8; font-size: 14px; margin-bottom: 2px; }
+.wimp-serie .ws-sub  { color: #6b6b6b; font-size: 11.5px; line-height: 1.45; }
+.wimp-serie .ws-box  {
+  display: table-cell; vertical-align: middle; width: 24px;
+  text-align: right; color: #3a3a3a; font-size: 17px;
+}
+.wimp-serie.on .ws-box { color: #5b9bf8; }
+.wimp-type {
+  /* prisadnutý k svojmu radu, aby bolo jasné, ku ktorému riadku patrí */
+  width: 92%; margin: -4px 0 10px auto; display: block;
+  -webkit-box-sizing: border-box; box-sizing: border-box;
+  background: #1b1b1b; border: 1px solid #2a2a2a; border-radius: 8px;
+  color: #ddd; font-size: 13px; padding: 8px 10px; outline: none;
+}
 /* ===== ODPAD: editor kalendára ===== */
 #waste-dialog {
   position: absolute; top: 0; left: 0; right: 0; bottom: 0;
@@ -1769,6 +1910,7 @@ html, body {
         <div class="wd-label" id="t-waste-rules-label"></div>
         <div id="waste-rule-list"></div>
         <button class="wd-btn ghost" id="t-waste-add-rule" onclick="wdNewRule()"></button>
+        <button class="wd-btn ghost" id="t-wimp-open" onclick="wimpOpen()"></button>
       </div>
 
       <div class="wd-group">
@@ -1779,6 +1921,19 @@ html, body {
       <div class="wd-status" id="waste-status"></div>
       <button class="wd-btn primary" id="t-waste-save" onclick="wdSaveConfig()"></button>
       <button class="wd-btn" id="t-waste-close" onclick="closeWasteDialog()"></button>
+    </div>
+
+    <!-- import harmonogramu -->
+    <div id="waste-import" style="display:none">
+      <div class="wimp-intro" id="t-wimp-intro"></div>
+      <input type="file" id="waste-import-file" accept=".pdf,.png,.jpg,.jpeg,image/*,application/pdf"
+             onchange="wimpUpload(this)">
+      <button class="wd-btn" id="t-wimp-pick"
+              onclick="document.getElementById('waste-import-file').click()"></button>
+      <div class="wd-status" id="wimp-status"></div>
+      <div id="wimp-result"></div>
+      <button class="wd-btn primary" id="t-wimp-add" style="display:none" onclick="wimpAdd()"></button>
+      <button class="wd-btn" id="t-wimp-cancel" onclick="wimpClose()"></button>
     </div>
 
     <!-- editor jedného zvozu -->
@@ -2084,6 +2239,12 @@ function applyTranslations() {
   document.getElementById("t-waste-rule-ok").textContent        = tr("waste_save");
   document.getElementById("t-waste-rule-cancel").textContent    = tr("waste_cancel");
   document.getElementById("t-waste-rule-delete").textContent    = tr("waste_delete");
+  // — import harmonogramu —
+  document.getElementById("t-wimp-open").textContent   = tr("wimp_open");
+  document.getElementById("t-wimp-intro").textContent  = tr("wimp_intro");
+  document.getElementById("t-wimp-pick").textContent   = tr("wimp_pick");
+  document.getElementById("t-wimp-add").textContent    = tr("wimp_add");
+  document.getElementById("t-wimp-cancel").textContent = tr("waste_cancel");
 }
 
 // ── Settings (sleep theme) ──────────────────────────────────────────────────
@@ -2679,6 +2840,7 @@ function openWasteDialog() {
   document.getElementById("waste-dialog").style.display = "block";
   document.getElementById("waste-main").style.display   = "block";
   document.getElementById("waste-editor").style.display = "none";
+  document.getElementById("waste-import").style.display = "none";
   document.getElementById("waste-dialog").scrollTop     = 0;
   wdStatus("", "");
   xhrGet("/waste/config", function(err, text) {
@@ -2861,6 +3023,140 @@ function wdSaveConfig() {
     });
   };
   xhr.send(JSON.stringify(wdCfg));
+}
+
+// ── Import harmonogramu ──────────────────────────────────────────────────────
+var wimpSeries = [];   // rady rozpoznané zo súboru
+var wimpYear   = 0;
+
+function wimpOpen() {
+  document.getElementById("waste-main").style.display   = "none";
+  document.getElementById("waste-import").style.display = "block";
+  document.getElementById("waste-dialog").scrollTop     = 0;
+  wimpReset();
+}
+
+function wimpClose() {
+  document.getElementById("waste-import").style.display = "none";
+  document.getElementById("waste-main").style.display   = "block";
+  document.getElementById("waste-dialog").scrollTop     = 0;
+  wimpReset();
+  wdRenderMain();
+}
+
+function wimpReset() {
+  wimpSeries = []; wimpYear = 0;
+  document.getElementById("wimp-result").innerHTML = "";
+  document.getElementById("waste-import-file").value = "";
+  document.getElementById("t-wimp-add").style.display = "none";
+  wimpStatus("", "");
+}
+
+function wimpStatus(msg, cls) {
+  var el = document.getElementById("wimp-status");
+  el.innerHTML = escHtml(msg || "");
+  el.className = "wd-status" + (cls ? " " + cls : "");
+}
+
+function wimpErrKey(code) {
+  if (code === "too_large")           { return "wimp_err_large"; }
+  if (code === "unsupported_format")  { return "wimp_err_format"; }
+  if (code === "no_api_key")          { return "wimp_err_novision"; }
+  if (code === "no_calendar_found" || code === "no_marks_found" ||
+      code === "pdf_parse_failed"     || code === "not_pdf") { return "wimp_err_parse"; }
+  return "wimp_err_generic";
+}
+
+function wimpUpload(input) {
+  if (!input.files || !input.files.length) { return; }
+  wimpStatus(tr("wimp_working"), "");
+  document.getElementById("wimp-result").innerHTML = "";
+  document.getElementById("t-wimp-add").style.display = "none";
+  var fd = new FormData();
+  fd.append("file", input.files[0]);
+  var xhr = new XMLHttpRequest();
+  xhr.open("POST", "/waste/import", true);
+  xhr.onreadystatechange = function() {
+    if (xhr.readyState !== 4) { return; }
+    var data = null;
+    try { data = JSON.parse(xhr.responseText); } catch (e) {}
+    if (!data || !data.ok) {
+      var code = data ? data.error : "";
+      // Ak parser neuspel a vision nie je k dispozícii, povedz to konkrétne.
+      if (data && data.vision_available === false && code !== "too_large") {
+        code = "no_api_key";
+      }
+      wimpStatus(tr(wimpErrKey(code)), "err");
+      return;
+    }
+    wimpSeries = data.series || [];
+    wimpYear   = data.year || 0;
+    for (var i = 0; i < wimpSeries.length; i++) {
+      wimpSeries[i].selected = false;
+      wimpSeries[i].type = wimpSeries[i].suggested_type || "other";
+    }
+    wimpStatus(tr(data.source === "vision" ? "wimp_via_vision" : "wimp_via_pdf"), "ok");
+    wimpRender();
+  };
+  xhr.send(fd);
+}
+
+function wimpRender() {
+  var host = document.getElementById("wimp-result");
+  if (!wimpSeries.length) { host.innerHTML = ""; return; }
+  var html = "<div class=\"wd-label\">"
+           + escHtml(trf("wimp_found", [wimpSeries.length, wimpYear])) + "</div>"
+           + "<div class=\"wimp-hint\">" + escHtml(tr("wimp_hint")) + "</div>";
+  for (var i = 0; i < wimpSeries.length; i++) {
+    var s = wimpSeries[i];
+    var sw = "background:" + escHtml(s.fill)
+           + (s.outline ? ";border-color:" + escHtml(s.outline) : "");
+    var sub = [];
+    if (s.summary) { sub.push(s.summary); }
+    sub.push(s.count + "\u00d7");
+    if (s.dates && s.dates.length) { sub.push(s.dates[0] + " \u2026 " + s.dates[s.dates.length - 1]); }
+    html += "<div class=\"wimp-serie" + (s.selected ? " on" : "") + "\" onclick=\"wimpToggle(" + i + ")\">"
+          + "<div class=\"ws-sw\"><div class=\"ws-chip\" style=\"" + sw + "\"></div></div>"
+          + "<div class=\"ws-txt\"><div class=\"ws-name\">"
+          + escHtml(s.colour_name || s.fill) + "</div>"
+          + "<div class=\"ws-sub\">" + escHtml(sub.join(" \u00b7 ")) + "</div></div>"
+          + "<div class=\"ws-box\">" + (s.selected ? "\u2713" : "\u25cb") + "</div></div>";
+    if (s.selected) {
+      html += "<select class=\"wimp-type\" onchange=\"wimpSetType(" + i + ",this.value)\">";
+      for (var j = 0; j < wdTypes.length; j++) {
+        html += "<option value=\"" + escHtml(wdTypes[j].id) + "\""
+              + (wdTypes[j].id === s.type ? " selected" : "") + ">"
+              + escHtml(wdTypes[j].icon + " " + wdTypes[j].label) + "</option>";
+      }
+      html += "</select>";
+    }
+  }
+  host.innerHTML = html;
+  var any = false;
+  for (var k = 0; k < wimpSeries.length; k++) { if (wimpSeries[k].selected) { any = true; } }
+  document.getElementById("t-wimp-add").style.display = any ? "" : "none";
+}
+
+function wimpToggle(i)      { wimpSeries[i].selected = !wimpSeries[i].selected; wimpRender(); }
+function wimpSetType(i, v)  { wimpSeries[i].type = v; }
+
+function wimpAdd() {
+  var added = 0;
+  for (var i = 0; i < wimpSeries.length; i++) {
+    var s = wimpSeries[i];
+    if (!s.selected || !s.dates || !s.dates.length) { continue; }
+    wdCfg.rules.push({
+      id: _newRuleId(), type: s.type, label: "",
+      recurrence: { kind: "dates", dates: s.dates.slice(0) },
+      from: "", to: "", skip: [], extra: []
+    });
+    added++;
+  }
+  if (!added) { wimpStatus(tr("wimp_none_selected"), "err"); return; }
+  // Import sám osebe nemá zmysel, kým je pripomienka vypnutá.
+  wdCfg.enabled = true;
+  wimpClose();
+  wdStatus(trf("wimp_added", [added]), "ok");
 }
 
 // ── Editor jedného zvozu ─────────────────────────────────────────────────────

--- a/tests/test_waste.py
+++ b/tests/test_waste.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Testy pre kalendár vývozu odpadu (snapframe/rootfs/usr/bin/waste.py).
+
+Dátumová matematika opakovaní je presne ten druh kódu, ktorý sa pokazí ticho,
+preto ju držíme pokrytú. Spustenie: `python3 -m unittest discover -s tests`
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from datetime import date
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "snapframe", "rootfs", "usr", "bin"))
+
+os.environ.setdefault("WASTE_CONFIG_FILE",
+                      os.path.join(tempfile.mkdtemp(), "waste_schedule.json"))
+
+import waste  # noqa: E402
+
+
+def cfg_with(*rules):
+    return waste.sanitize_config({"enabled": True, "rules": list(rules)})
+
+
+def dates_of(cfg, start, days=60):
+    return [o["date"] for o in waste.occurrences(cfg, start, days)]
+
+
+class TestWeekly(unittest.TestCase):
+    def test_every_week(self):
+        cfg = cfg_with({"type": "mixed", "recurrence": {
+            "kind": "weekly", "weekday": 3, "interval_weeks": 1}})
+        got = dates_of(cfg, date(2026, 8, 23), 22)
+        self.assertEqual(got, ["2026-08-27", "2026-09-03", "2026-09-10"])
+
+    def test_every_other_week_uses_anchor_phase(self):
+        cfg = cfg_with({"type": "mixed", "recurrence": {
+            "kind": "weekly", "weekday": 3, "interval_weeks": 2,
+            "anchor": "2026-08-27"}})
+        got = dates_of(cfg, date(2026, 8, 23), 36)
+        self.assertEqual(got, ["2026-08-27", "2026-09-10", "2026-09-24"])
+
+    def test_phase_holds_before_the_anchor(self):
+        """Kotva môže byť aj v budúcnosti – fáza musí platiť oboma smermi."""
+        cfg = cfg_with({"type": "mixed", "recurrence": {
+            "kind": "weekly", "weekday": 3, "interval_weeks": 2,
+            "anchor": "2026-08-27"}})
+        got = dates_of(cfg, date(2026, 8, 1), 27)
+        self.assertEqual(got, ["2026-08-13", "2026-08-27"])
+
+    def test_misaligned_anchor_is_snapped_to_the_weekday(self):
+        """Používateľ zadá dátum, ktorý nepadne na zvolený deň v týždni."""
+        cfg = cfg_with({"type": "mixed", "recurrence": {
+            "kind": "weekly", "weekday": 3, "interval_weeks": 2,
+            "anchor": "2026-08-29"}})          # sobota, nie štvrtok
+        self.assertEqual(dates_of(cfg, date(2026, 8, 23), 22),
+                         ["2026-08-27", "2026-09-10"])
+
+    def test_interval_without_anchor_falls_back_to_every_week(self):
+        cfg = cfg_with({"type": "mixed", "recurrence": {
+            "kind": "weekly", "weekday": 0, "interval_weeks": 3}})
+        self.assertEqual(cfg["rules"][0]["recurrence"]["interval_weeks"], 1)
+
+
+class TestMonthly(unittest.TestCase):
+    def test_first_monday(self):
+        cfg = cfg_with({"type": "paper", "recurrence": {
+            "kind": "monthly", "monthly_by": "weekday",
+            "weekday": 0, "week_of_month": 1}})
+        self.assertEqual(dates_of(cfg, date(2026, 8, 1), 130),
+                         ["2026-08-03", "2026-09-07", "2026-10-05",
+                          "2026-11-02", "2026-12-07"])
+
+    def test_last_friday(self):
+        cfg = cfg_with({"type": "paper", "recurrence": {
+            "kind": "monthly", "monthly_by": "weekday",
+            "weekday": 4, "week_of_month": -1}})
+        self.assertEqual(dates_of(cfg, date(2026, 8, 1), 100),
+                         ["2026-08-28", "2026-09-25", "2026-10-30"])
+
+    def test_fifth_weekday_is_skipped_in_months_without_one(self):
+        cfg = cfg_with({"type": "paper", "recurrence": {
+            "kind": "monthly", "monthly_by": "weekday",
+            "weekday": 0, "week_of_month": 5}})
+        got = dates_of(cfg, date(2026, 1, 1), 365)
+        for iso in got:
+            y, m, d = [int(x) for x in iso.split("-")]
+            self.assertEqual(date(y, m, d).weekday(), 0)
+            self.assertGreaterEqual(d, 29)
+        self.assertLess(len(got), 12)   # nie každý mesiac má 5. pondelok
+
+    def test_by_day_of_month_with_month_filter(self):
+        cfg = cfg_with({"type": "glass", "recurrence": {
+            "kind": "monthly", "monthly_by": "day",
+            "day_of_month": 15, "months": [8, 10]}})
+        self.assertEqual(dates_of(cfg, date(2026, 8, 1), 120),
+                         ["2026-08-15", "2026-10-15"])
+
+    def test_day_31_only_lands_in_long_months(self):
+        cfg = cfg_with({"type": "glass", "recurrence": {
+            "kind": "monthly", "monthly_by": "day", "day_of_month": 31}})
+        # apríl má 30 dní – vypadne, marec a máj ostanú
+        self.assertEqual(dates_of(cfg, date(2026, 2, 1), 120),
+                         ["2026-03-31", "2026-05-31"])
+
+
+class TestOverrides(unittest.TestCase):
+    def test_skip_and_extra(self):
+        cfg = cfg_with({"type": "bio", "recurrence": {
+            "kind": "weekly", "weekday": 0, "interval_weeks": 1},
+            "skip": ["2026-08-31"], "extra": ["2026-09-02"]})
+        got = dates_of(cfg, date(2026, 8, 24), 21)
+        self.assertIn("2026-08-24", got)
+        self.assertNotIn("2026-08-31", got)     # výnimka
+        self.assertIn("2026-09-02", got)        # mimoriadny termín (streda)
+
+    def test_skip_wins_over_extra(self):
+        cfg = cfg_with({"type": "bio", "recurrence": {"kind": "dates", "dates": []},
+                        "skip": ["2026-09-02"], "extra": ["2026-09-02"]})
+        self.assertEqual(dates_of(cfg, date(2026, 9, 1), 10), [])
+
+    def test_extra_ignores_validity_range(self):
+        cfg = cfg_with({"type": "bulky", "recurrence": {
+            "kind": "weekly", "weekday": 0, "interval_weeks": 1},
+            "from": "2026-09-01", "to": "2026-09-30",
+            "extra": ["2026-10-20"]})
+        got = dates_of(cfg, date(2026, 8, 1), 120)
+        self.assertNotIn("2026-08-31", got)     # pred „platí od“
+        self.assertIn("2026-09-07", got)
+        self.assertNotIn("2026-10-05", got)     # po „platí do“
+        self.assertIn("2026-10-20", got)        # mimoriadny termín platí vždy
+
+    def test_two_rules_same_day_are_merged(self):
+        cfg = cfg_with(
+            {"type": "plastic", "recurrence": {"kind": "dates", "dates": ["2026-09-03"]}},
+            {"type": "paper",   "recurrence": {"kind": "dates", "dates": ["2026-09-03"]}})
+        occ = waste.occurrences(cfg, date(2026, 9, 1), 10)
+        self.assertEqual(len(occ), 1)
+        self.assertEqual([t["id"] for t in occ[0]["types"]], ["plastic", "paper"])
+
+    def test_duplicate_type_on_same_day_is_deduplicated(self):
+        cfg = cfg_with(
+            {"type": "bio", "recurrence": {"kind": "dates", "dates": ["2026-09-03"]}},
+            {"type": "bio", "recurrence": {"kind": "dates", "dates": ["2026-09-03"]}})
+        occ = waste.occurrences(cfg, date(2026, 9, 1), 10)
+        self.assertEqual(len(occ[0]["types"]), 1)
+
+    def test_custom_label_keeps_types_distinct(self):
+        cfg = cfg_with(
+            {"type": "plastic", "label": "Žlté vrecia",
+             "recurrence": {"kind": "dates", "dates": ["2026-09-03"]}},
+            {"type": "plastic", "label": "Kovy do vriec",
+             "recurrence": {"kind": "dates", "dates": ["2026-09-03"]}})
+        occ = waste.occurrences(cfg, date(2026, 9, 1), 10)
+        self.assertEqual([t["label"] for t in occ[0]["types"]],
+                         ["Žlté vrecia", "Kovy do vriec"])
+
+
+class TestSanitize(unittest.TestCase):
+    def test_junk_input_never_raises(self):
+        for junk in (None, [], "text", 42, {"rules": "nope"}, {"rules": [None, 1, {}]}):
+            self.assertIsInstance(waste.sanitize_config(junk), dict)
+
+    def test_values_are_clamped_and_whitelisted(self):
+        cfg = waste.sanitize_config({
+            "mode": "../../etc/passwd", "photo_interval": 10 ** 9,
+            "days_before": -5, "start_hour": 99})
+        self.assertEqual(cfg["mode"], "overlay")
+        self.assertEqual(cfg["photo_interval"], 100)
+        self.assertEqual(cfg["days_before"], 0)
+        self.assertEqual(cfg["start_hour"], 23)
+
+    def test_days_before_zero_forces_show_on_day(self):
+        cfg = waste.sanitize_config({"days_before": 0, "show_on_day": False})
+        self.assertTrue(cfg["show_on_day"])
+
+    def test_unknown_waste_type_falls_back_to_other(self):
+        cfg = cfg_with({"type": "<script>", "recurrence": {
+            "kind": "dates", "dates": ["2026-09-03"]}})
+        self.assertEqual(cfg["rules"][0]["type"], "other")
+
+    def test_rule_without_any_date_is_dropped(self):
+        self.assertEqual(cfg_with({"type": "bio",
+                                   "recurrence": {"kind": "dates", "dates": []}})["rules"], [])
+
+    def test_invalid_dates_are_discarded_and_list_is_sorted(self):
+        cfg = cfg_with({"type": "bio", "recurrence": {
+            "kind": "dates",
+            "dates": ["2026-09-03", "nope", "2026-13-45", "2026-08-01", "2026-09-03"]}})
+        self.assertEqual(cfg["rules"][0]["recurrence"]["dates"],
+                         ["2026-08-01", "2026-09-03"])
+
+    def test_rule_ids_are_made_unique(self):
+        cfg = cfg_with(
+            {"id": "x", "type": "bio", "recurrence": {"kind": "dates", "dates": ["2026-09-03"]}},
+            {"id": "x", "type": "paper", "recurrence": {"kind": "dates", "dates": ["2026-09-04"]}})
+        self.assertNotEqual(cfg["rules"][0]["id"], cfg["rules"][1]["id"])
+
+    def test_rule_count_is_capped(self):
+        many = [{"type": "bio", "recurrence": {"kind": "dates", "dates": ["2026-09-03"]}}
+                for _ in range(waste.MAX_RULES + 25)]
+        self.assertEqual(len(cfg_with(*many)["rules"]), waste.MAX_RULES)
+
+
+class TestPersistence(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.old = waste.CONFIG_FILE
+        waste.CONFIG_FILE = os.path.join(self.dir, "sub", "waste_schedule.json")
+
+    def tearDown(self):
+        waste.CONFIG_FILE = self.old
+
+    def test_missing_file_yields_defaults(self):
+        cfg = waste.load_config()
+        self.assertFalse(cfg["enabled"])
+        self.assertEqual(cfg["rules"], [])
+
+    def test_save_then_load_roundtrip(self):
+        cfg = cfg_with({"type": "bio", "recurrence": {
+            "kind": "weekly", "weekday": 2, "interval_weeks": 1}})
+        waste.save_config(cfg)
+        self.assertEqual(waste.load_config(), cfg)
+
+    def test_corrupted_file_falls_back_to_defaults(self):
+        os.makedirs(os.path.dirname(waste.CONFIG_FILE), exist_ok=True)
+        with open(waste.CONFIG_FILE, "w", encoding="utf-8") as f:
+            f.write("{ this is not json")
+        self.assertEqual(waste.load_config()["rules"], [])
+
+
+class TestNextCollection(unittest.TestCase):
+    def test_today_counts_as_next(self):
+        cfg = cfg_with({"type": "bio", "recurrence": {
+            "kind": "dates", "dates": ["2026-09-03", "2026-09-10"]}})
+        nxt = waste.next_collection(cfg, date(2026, 9, 3))
+        self.assertEqual((nxt["date"], nxt["days_until"]), ("2026-09-03", 0))
+
+    def test_days_until_is_relative_to_the_given_day(self):
+        cfg = cfg_with({"type": "bio", "recurrence": {
+            "kind": "dates", "dates": ["2026-09-10"]}})
+        self.assertEqual(waste.next_collection(cfg, date(2026, 9, 3))["days_until"], 7)
+
+    def test_no_upcoming_collection_returns_none(self):
+        cfg = cfg_with({"type": "bio", "recurrence": {
+            "kind": "dates", "dates": ["2020-01-01"]}})
+        self.assertIsNone(waste.next_collection(cfg, date(2026, 9, 3)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_waste_import.py
+++ b/tests/test_waste_import.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Testy pre import zvozového harmonogramu (waste_import.py).
+
+Geometrické parsovanie sa dá ticho pokaziť zmenou jednej konštanty, preto sú
+testy postavené na PDF, ktoré si sami vygenerujeme – vieme teda presne, ktoré
+dni sú označené, a môžeme overiť, že parser vráti presne tie.
+"""
+
+import io
+import os
+import sys
+import unittest
+from datetime import date
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "snapframe", "rootfs", "usr", "bin"))
+
+import waste_import as wi  # noqa: E402
+
+try:
+    import reportlab  # noqa: F401
+    HAVE_REPORTLAB = True
+except ImportError:
+    HAVE_REPORTLAB = False
+
+try:
+    import pdfplumber  # noqa: F401
+    HAVE_PDFPLUMBER = True
+except ImportError:
+    HAVE_PDFPLUMBER = False
+
+
+def build_pdf(marks, year=2026, weeks=tuple(range(1, 13))):
+    """Malý kalendár: riadok = ISO týždeň, stĺpec = deň. `marks` = {date: (rgb, edge)}."""
+    from reportlab.lib.pagesizes import A4
+    from reportlab.pdfgen import canvas
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf, pagesize=A4)
+    c.setFont("Helvetica", 8)
+    c.drawString(40, 800, "Zvozovy harmonogram {}".format(year))
+    x0, y0, cw, ch = 60, 760, 22.0, 16.0
+    for i, name in enumerate(["Po", "Ut", "St", "St", "Pi"]):
+        c.drawString(x0 + 30 + i * cw + 6, y0 + 6, ["Po", "Ut", "St", "Št", "Pi"][i])
+    for row, wk in enumerate(weeks):
+        y = y0 - (row + 1) * ch
+        c.drawString(x0, y + 4, "{}.".format(wk))
+        for col in range(5):
+            try:
+                d = date.fromisocalendar(year, wk, col + 1)
+            except ValueError:
+                continue
+            cx = x0 + 30 + col * cw
+            if d in marks:
+                rgb, edge = marks[d]
+                if edge:
+                    c.setFillColorRGB(*edge)
+                    for ex, ey, ew, eh in ((cx, y - 3, cw, 3), (cx, y + ch, cw, 3),
+                                           (cx - 3, y, 3, ch), (cx + cw, y, 3, ch)):
+                        c.rect(ex, ey, ew, eh, stroke=0, fill=1)
+                c.setFillColorRGB(*rgb)
+                c.rect(cx, y, cw, ch, stroke=0, fill=1)
+            c.setFillColorRGB(0, 0, 0) if d not in marks else c.setFillColorRGB(1, 1, 1)
+            c.drawString(cx + 7, y + 4, str(d.day))
+            c.setFillColorRGB(0, 0, 0)
+    c.showPage()
+    c.save()
+    return buf.getvalue()
+
+
+class TestHelpers(unittest.TestCase):
+    def test_colour_normalisation(self):
+        self.assertEqual(wi._norm_colour(0.0), (0.0, 0.0, 0.0))       # grayscale
+        self.assertEqual(wi._norm_colour([0.5]), (0.5, 0.5, 0.5))     # 1-zložkové
+        self.assertEqual(wi._norm_colour((1, 0, 0)), (1, 0, 0))       # RGB
+        self.assertEqual(wi._norm_colour((0, 0, 0, 0)), (1, 1, 1))    # CMYK biela
+        self.assertIsNone(wi._norm_colour(None))
+        self.assertIsNone(wi._norm_colour("modra"))
+
+    def test_background_detection(self):
+        self.assertTrue(wi._is_background((1.0, 1.0, 1.0)))
+        self.assertTrue(wi._is_background((0.851, 0.851, 0.851)))     # mriežka
+        self.assertFalse(wi._is_background((0.0, 0.0, 0.0)))
+        self.assertFalse(wi._is_background((1.0, 1.0, 0.0)))          # žltá je značka
+
+    def test_hex_output(self):
+        self.assertEqual(wi._hex((0, 0, 0)), "#000000")
+        self.assertEqual(wi._hex((1, 1, 0)), "#ffff00")
+
+    def test_colour_hints(self):
+        self.assertEqual(wi._colour_hint((1.0, 1.0, 0.0))[0], "plastic")
+        self.assertEqual(wi._colour_hint((0.0, 0.69, 0.94))[0], "paper")
+        self.assertEqual(wi._colour_hint((0.80, 0.40, 0.10))[0], "bio")
+        self.assertEqual(wi._colour_hint((0.0, 0.0, 0.0))[0], "mixed")
+        self.assertEqual(wi._colour_hint((0.5, 1.0, 1.0))[0], "other")     # bledá tyrkysová – ďaleko od všetkých
+
+    def test_year_guess(self):
+        today = date(2026, 5, 1)
+        self.assertEqual(wi._guess_year("Harmonogram 2026", today), 2026)
+        self.assertEqual(wi._guess_year("nic tu nie je", today), 2026)
+        self.assertEqual(wi._guess_year("rok 1998", today), 2026)           # nepravdepodobný
+        self.assertEqual(wi._guess_year("", date(2026, 12, 3)), 2027)       # v decembri už ďalší
+
+    def test_summary(self):
+        every2 = [date.fromordinal(date(2026, 1, 1).toordinal() + 14 * i) for i in range(6)]
+        self.assertIn("každé 2 týždne", wi._summarise(every2, "sk"))
+        self.assertIn("štvrtok", wi._summarise(every2, "sk"))
+        self.assertIn("every 2 weeks", wi._summarise(every2, "en"))
+        self.assertEqual(wi._summarise([], "sk"), "")
+
+    def test_missing_dependency_is_reported_not_raised(self):
+        self.assertFalse(wi.parse_pdf(b"nie je to pdf")["ok"])
+
+    def test_vision_without_key_is_reported(self):
+        r = wi.parse_with_vision(b"x", "image/png", api_key="")
+        self.assertEqual(r["error"], "no_api_key")
+
+
+@unittest.skipUnless(HAVE_REPORTLAB and HAVE_PDFPLUMBER,
+                     "vyžaduje reportlab + pdfplumber")
+class TestParsePdf(unittest.TestCase):
+    BLACK, YELLOW, GREEN = (0, 0, 0), (1, 1, 0), (0.57, 0.82, 0.31)
+
+    def test_extracts_exactly_the_marked_days(self):
+        marks = {date(2026, 1, 1): (self.BLACK, None),
+                 date(2026, 1, 15): (self.BLACK, None),
+                 date(2026, 1, 29): (self.BLACK, None)}
+        r = wi.parse_pdf(build_pdf(marks))
+        self.assertTrue(r["ok"], r)
+        self.assertEqual(r["year"], 2026)
+        black = [s for s in r["series"] if s["fill"] == "#000000"]
+        self.assertTrue(black)
+        self.assertEqual(black[0]["dates"],
+                         ["2026-01-01", "2026-01-15", "2026-01-29"])
+
+    def test_two_colours_become_two_series(self):
+        marks = {date(2026, 1, 1): (self.BLACK, None),
+                 date(2026, 1, 15): (self.BLACK, None),
+                 date(2026, 1, 5): (self.YELLOW, None),
+                 date(2026, 1, 19): (self.YELLOW, None)}
+        r = wi.parse_pdf(build_pdf(marks))
+        fills = {s["fill"] for s in r["series"]}
+        self.assertIn("#000000", fills)
+        self.assertIn("#ffff00", fills)
+
+    def test_outline_yields_both_a_subset_and_an_aggregate(self):
+        """Rámik označuje podmnožinu – používateľ musí vidieť aj celok, aj časť."""
+        marks = {date(2026, 1, 1): (self.BLACK, self.GREEN),
+                 date(2026, 1, 15): (self.BLACK, None),
+                 date(2026, 1, 29): (self.BLACK, self.GREEN)}
+        r = wi.parse_pdf(build_pdf(marks))
+        black_all = [s for s in r["series"]
+                     if s["fill"] == "#000000" and s["aggregate"]]
+        self.assertEqual(len(black_all), 1)
+        self.assertEqual(len(black_all[0]["dates"]), 3)          # celý rad
+        green = [s for s in r["series"] if s["fill"].lower() in ("#92d14f", "#92d14e", "#92d150")
+                 or s["colour_name"] == "zelená"]
+        self.assertTrue(green, [s["fill"] for s in r["series"]])
+        self.assertEqual(len(green[0]["dates"]), 2)              # iba orámované dni
+
+    def test_suggested_type_follows_the_colour(self):
+        marks = {date(2026, 1, 5): (self.YELLOW, None),
+                 date(2026, 1, 19): (self.YELLOW, None)}
+        r = wi.parse_pdf(build_pdf(marks))
+        yellow = [s for s in r["series"] if s["fill"] == "#ffff00"][0]
+        self.assertEqual(yellow["suggested_type"], "plastic")
+
+    def test_single_occurrence_is_ignored_as_legend(self):
+        marks = {date(2026, 1, 5): (self.YELLOW, None)}
+        r = wi.parse_pdf(build_pdf(marks))
+        self.assertFalse([s for s in r.get("series", []) if s["fill"] == "#ffff00"])
+
+    def test_calendar_without_marks_is_reported(self):
+        r = wi.parse_pdf(build_pdf({}))
+        self.assertFalse(r["ok"])
+        self.assertIn(r["error"], ("no_marks_found", "no_calendar_found"))
+
+    def test_garbage_input_never_raises(self):
+        for junk in (b"", b"not a pdf", b"%PDF-1.4 broken", os.urandom(400)):
+            self.assertFalse(wi.parse_pdf(junk)["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Set up which days of the year each waste type is collected, and the frame reminds you the day before which bin goes out — so the container actually makes it to the kerb.

Off by default: existing installs see no change until a schedule is set up.

## The design decisions

**Rules, not a flat list of dates.** Real municipal calendars are almost always *"mixed waste, every other Thursday"* or *"paper, first Monday of the month"*. Typing ~50 dates a year and redoing it every January is the thing that makes this kind of feature get abandoned. So a collection is a **rule**:

| Kind | Configured with |
|---|---|
| Every N weeks | weekday, N (1–12), and a **reference date** — one real collection day, which fixes *which* week is the right one |
| Monthly | position in month (first…fifth or **last**) + weekday, **or** a day number; optionally limited to certain months |
| Specific dates | a list, for irregular pickups |

Plus, per rule: validity range (*valid from/until* — e.g. bio waste only April–November), **exceptions** (public holidays), **extra one-off dates** (a pickup moved because of a holiday), and a custom name override.

**Configured in the app, not in the add-on options.** A year of dates is miserable to maintain as YAML and every edit would need an add-on restart. The schedule lives in `/data/waste_schedule.json` (survives restarts and updates) behind a full editor at Settings → *"Waste collection…"*, and is shared by every tablet pointed at the add-on. Everything coming from the browser is validated and clamped server-side.

**The tablet decides what "tomorrow" is.** The server only expands and ships the list of upcoming collection days; the browser picks the alert using its own local time. An add-on container running in UTC therefore can't shift the reminder by a day — which is exactly the bug this feature would be most embarrassing to have.

## What it looks like

Two display modes, independently selectable (or both):

- **Corner badge** — a high-contrast badge over the photos, up the whole time the reminder is active
- **Full screen** — a reminder inserted between photos every *N* photos, following the existing weather-screen pattern

Timing: remind 0–7 days ahead (default 1), optionally also on the collection day itself (today wins over tomorrow when both have collections), and an optional *"not before this hour"* gate so you're not reading "tomorrow: plastic" at 6 a.m.

The badge stays hidden during the weather screen, during night mode, and outside the slideshow. The waste and weather slides keep separate photo counters so they interleave cleanly instead of fighting.

Ten built-in waste types (mixed, bio, plastic, paper, glass, metal, drink cartons, e-waste, bulky, other), each with an icon and colour. Two collections on the same day merge into one reminder. Full SK/EN/DE translations, including human-readable rule summaries in the editor ("Štvrtok · každý 2. týždeň", "posledný pondelok (mar, sep)").

## Home Assistant

`GET /waste/next` is shaped for a REST sensor (`state` is the next collection date, with `days_until` and the waste types), so the same schedule can also drive a phone notification. Example sensor + automation are in the add-on README.

## Changes

- **New** `snapframe/rootfs/usr/bin/waste.py` — schedule model, recurrence expansion, config load/save/sanitise
- `webserver.py` — four endpoints (`GET`/`POST /waste/config`, `GET /waste/status`, `GET /waste/next`), the badge + full-screen slide, and the calendar editor UI
- **New** `tests/test_waste.py` — 30 cases covering recurrence phases, month edge cases (5th Monday, day 31, last Friday), skip/extra precedence, validity ranges and config sanitisation; wired into the existing CI Python job
- Version bump to 2.10.0, CHANGELOG entry, README docs

## Old-iPad compatibility

Front-end sticks to the constraints the rest of the app already follows: ES5 only, a px fallback before every `clamp()`, `display: table` instead of flex `gap`, and a `display: block` fallback on the slide so it can never end up stuck hidden on a browser that understands neither `flex` nor `-webkit-flex`.

## Verification

- 30 unit tests pass; `compileall`, `ruff` (E9,F63,F7,F82) and the CI version/changelog gate all pass locally
- Driven end-to-end in a real browser with Playwright: created all three rule kinds through the editor, saved, and confirmed the badge and the full-screen reminder render correctly in landscape and portrait, with no JS errors
- Reminder logic checked case by case in-page: lead time, disabled, today-vs-tomorrow precedence, `show_on_day` off, the start-hour gate (and that the same-day reminder correctly ignores it), multi-type days, mode gating, and the badge hiding outside the slideshow and during night mode
- Verified the feature is inert with no config in all three languages, and that the app degrades gracefully if `waste.py` fails to import

---
_Generated by [Claude Code](https://claude.ai/code/session_01AU42HL2bbgwtQyPzXTBdQV)_