### PR TITLE
SnapFrame 3.0.1 — fix the hourly weather strip showing UTC time

### DIFF
--- a/snapframe/CHANGELOG.md
+++ b/snapframe/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.1] – 2026
+
+### Fixed
+
+- **The hourly weather strip showed the wrong time.** Home Assistant sends the hourly forecast in UTC, but the label was only ever built from that UTC string without converting to local time — the data itself was correct, only mislabelled, by exactly the UTC offset (2 hours in summer, 1 in winter). The server now converts using the container's own timezone when it has one (`TZ`, which the Supervisor normally sets), and the hourly payload also carries the raw ISO timestamp so the browser — which, like the tablet driving the waste-collection reminders, has a timezone the container can't be sure of — computes the label itself.
+
 ## [3.0.0] – 2026
 
 ### Security

--- a/snapframe/config.yaml
+++ b/snapframe/config.yaml
@@ -1,5 +1,5 @@
 name: "SnapFrame – Digital Photo Frame"
-version: "3.0.0"
+version: "3.0.1"
 slug: "snapframe"
 description: "Turn any old tablet or iPad into a smart digital photo frame. Watches an SMB share, converts HEIC/HEIF to JPG, and serves a fullscreen slideshow with albums, EXIF date/GPS overlay, swipe gestures, web upload, night mode, a motion-triggered weather screen and waste-collection reminders. Home Assistant ingress and MQTT discovery included."
 url: "https://github.com/emo546/ha-snapframe"

--- a/snapframe/rootfs/usr/bin/webserver.py
+++ b/snapframe/rootfs/usr/bin/webserver.py
@@ -1106,13 +1106,24 @@ def status_route():
 # ── Weather mode (spúšťané pohybovým senzorom cez HA automatizáciu) ───────────
 
 def _hour_label(dt_str: str) -> str:
-    """Z ISO datetime (napr. '2026-07-13T14:00:00+00:00') urobí 'HH:MM'."""
+    """Z ISO datetime (napr. '2026-07-13T14:00:00+00:00') urobí 'HH:MM'.
+
+    HA posiela tieto časy v UTC. Predtým sa tu len odsekol ciferník bez
+    prevodu do lokálnej zóny, takže hodinová predpoveď bola posunutá presne
+    o UTC offset (v lete o 2 h) – dáta boli správne, len zle popísané.
+    Kontajner môže, ale nemusí mať TZ nastavené (Supervisor ho zvyčajne
+    posiela); .astimezone() bez argumentu prevedie do lokálnej zóny hostiteľa,
+    keď je známa, inak vráti pôvodný čas nezmenený.
+    """
     s = str(dt_str or "")
     try:
         clean = s.replace("Z", "+00:00")
-        return datetime.fromisoformat(clean).strftime("%H:%M")
+        dt = datetime.fromisoformat(clean)
+        if dt.tzinfo is not None:
+            dt = dt.astimezone()
+        return dt.strftime("%H:%M")
     except (ValueError, TypeError):
-        # Fallback: skús vyseknúť hodinu z reťazca "....THH:MM..."
+        # Fallback: skús vyseknúť hodinu z reťazca "....THH:MM..." (bez prevodu zóny)
         if "T" in s and len(s) >= 16:
             return s[11:16]
         return ""
@@ -1129,8 +1140,13 @@ def _parse_hourly(raw_list, max_items=12):
             temp = round(float(item.get("temperature")), 1)
         except (TypeError, ValueError):
             temp = None
+        iso = str(item.get("datetime") or "")
         out.append({
-            "time":      _hour_label(item.get("datetime")),
+            "time":      _hour_label(iso),
+            # Surový ISO čas navyše – prehliadač na tablete má na rozdiel od
+            # kontajnera spoľahlivo správnu lokálnu časovú zónu (rovnaký princíp
+            # ako pri kalendári odpadu), takže si "time" môže prepočítať sám.
+            "iso":       iso,
             "temperature": temp,
             "condition": str(item.get("condition") or "")[:40],
         })

--- a/snapframe/rootfs/usr/share/snapframe/static/app.js
+++ b/snapframe/rootfs/usr/share/snapframe/static/app.js
@@ -659,6 +659,22 @@ function showWeatherSlide() {
   document.getElementById("weather-slide").className = "visible";
 }
 
+/** HH:MM v lokálnej zóne tabletu. iso prichádza z HA v UTC – kontajner
+ * add-onu nemá spoľahlivú lokálnu zónu, prehliadač na tablete áno (rovnaký
+ * princíp ako pri kalendári odpadu). Padá späť na h.time (spočítané na
+ * serveri), keď iso chýba alebo ho prehliadač nevie rozparsovať. */
+function _hourLocalTime(h) {
+  if (h.iso) {
+    var d = new Date(h.iso);
+    if (!isNaN(d.getTime())) {
+      var hh = d.getHours();
+      var mm = d.getMinutes();
+      return (hh < 10 ? "0" : "") + hh + ":" + (mm < 10 ? "0" : "") + mm;
+    }
+  }
+  return h.time || "";
+}
+
 function renderHourly(hourly) {
   var host = document.getElementById("weather-hourly");
   if (!hourly || !hourly.length) { host.innerHTML = ""; host.style.display = "none"; return; }
@@ -682,7 +698,7 @@ function renderHourly(hourly) {
     var ico  = WEATHER_EMOJI[h.condition] || "🌡️";
     var temp = (h.temperature != null) ? Math.round(h.temperature) + "°" : "--";
     html += "<div class=\"weather-hour" + (j === 0 ? " now" : "") + "\">"
-          + "<div class=\"wh-time\">" + escHtml(h.time || "") + "</div>"
+          + "<div class=\"wh-time\">" + escHtml(_hourLocalTime(h)) + "</div>"
           + "<div class=\"wh-ico\">" + ico + "</div>"
           + "<div class=\"wh-temp\">" + escHtml(temp) + "</div>"
           + "</div>";

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -58,6 +59,54 @@ class WebTestCase(unittest.TestCase):
             photoindex._conn.close()
             photoindex._conn = None
         shutil.rmtree(self.root, ignore_errors=True)
+
+
+class TestWeatherHourLabel(unittest.TestCase):
+    """HA posiela hodinovú predpoveď v UTC – _hour_label musí prevádzať do
+    lokálnej zóny kontajnera, nielen odseknúť ciferník z UTC reťazca.
+    Predtým sa 14:00 UTC v CEST (+02:00) zobrazovalo ako '14:00', teda
+    o dve hodiny v minulosti."""
+
+    def setUp(self):
+        self._orig_tz = os.environ.get("TZ")
+        os.environ["TZ"] = "Europe/Bratislava"
+        time.tzset()
+
+    def tearDown(self):
+        if self._orig_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = self._orig_tz
+        time.tzset()
+
+    def test_utc_offset_is_applied_in_summer(self):
+        # CEST je UTC+2 – 14:00 UTC musí byť 16:00 lokálne, nie 14:00.
+        self.assertEqual(webserver._hour_label("2026-08-23T14:00:00+00:00"), "16:00")
+
+    def test_z_suffix_is_treated_as_utc(self):
+        self.assertEqual(webserver._hour_label("2026-08-23T14:00:00Z"), "16:00")
+
+    def test_already_local_offset_is_respected(self):
+        self.assertEqual(webserver._hour_label("2026-08-23T16:00:00+02:00"), "16:00")
+
+    def test_naive_datetime_is_left_unconverted(self):
+        # Bez zóny niet čo prevádzať – ostáva ako fallback.
+        self.assertEqual(webserver._hour_label("2026-08-23T14:00:00"), "14:00")
+
+    def test_garbage_input_never_raises(self):
+        self.assertEqual(webserver._hour_label(""), "")
+        self.assertEqual(webserver._hour_label(None), "")
+        self.assertEqual(webserver._hour_label("not-a-date"), "")
+
+    def test_hourly_payload_carries_the_raw_iso_time_too(self):
+        """Prehliadač na tablete má spoľahlivejšiu lokálnu zónu než kontajner
+        (rovnaký princíp ako pri kalendári odpadu) – iso musí prejsť ďalej
+        nezmenené, aby si čas vedel prepočítať sám."""
+        out = webserver._parse_hourly([
+            {"datetime": "2026-08-23T14:00:00+00:00", "temperature": 21.4, "condition": "sunny"},
+        ])
+        self.assertEqual(out[0]["iso"], "2026-08-23T14:00:00+00:00")
+        self.assertEqual(out[0]["time"], "16:00")
 
 
 class TestPathTraversal(WebTestCase):


### PR DESCRIPTION
Fixes the "weather mode looks ~2 hours behind" report.

## Root cause

`_hour_label()` parsed the ISO datetime Home Assistant sends for the hourly forecast (UTC) but never converted it before formatting — `datetime.fromisoformat(...).strftime("%H:%M")` just prints the instant's own clock face, tzinfo and all, with no conversion. The forecast **data** was correct; only the **label** was off, by exactly the UTC offset — 2 hours in summer (CEST), 1 in winter (CET) — which reads as a stale or delayed forecast even though it isn't. Current temperature, humidity, condition and the computed min/max were unaffected; only the hourly strip's time labels were wrong.

## Fix

- `webserver.py`: `_hour_label()` now applies `.astimezone()` so the label follows the container's own timezone when one is set (the Supervisor normally sets `TZ`).
- The hourly payload also now carries the raw ISO timestamp (`iso`) alongside the formatted label, and the browser recomputes the label in the tablet's own timezone when it can parse the date (`app.js`, ES5-compatible — no `padStart`, to match the rest of the file and stay usable on old iPads). The container's `TZ` is a best-effort fallback, not something to rely on — same reasoning the waste-collection reminders already use: the browser knows the true local time, the container might not.
- 6 new tests cover the UTC-offset conversion (including a `Z` suffix and an already-local offset), the naive-datetime fallback, garbage input, and that `iso` survives into the parsed payload. 82 → 88 tests, all passing.

## Verified locally

88 tests (0 skips), ruff, `node --check`, shellcheck, hadolint (error threshold). Reproduced the original bug against `_hour_label` directly before fixing it (`2026-08-23T14:00:00+00:00` rendered as `14:00` instead of `16:00` in `Europe/Bratislava`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqamReWvuuiZUPAME67xPP)_