### PR TITLE
Weather: use only the shape of the forecast, not its absolute values

### DIFF
--- a/snapframe/CHANGELOG.md
+++ b/snapframe/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.1.1] – 2026
+
+### Fixed
+
+- **The derived temperature carried the forecast's bias, so it read a couple of degrees off all day.** 3.1.0 falls back to the hourly forecast once the last push is older than 20 minutes — but it took the forecast's *absolute* value, and a forecast does not agree with the measurement it sits next to: OpenWeatherMap's hourly forecast routinely runs a degree or two away from the same integration's own current temperature. A frame whose automation pushes once in the morning therefore spent the whole day showing that offset. The forecast is now used only for its **shape**: the difference between the measurement and the forecast at the moment of the push is carried forward, so the curve passes through the last real measurement and tracks how much it has warmed or cooled since. The offset is clamped to ±5 °C so one odd reading cannot skew the display. A welcome side effect is that crossing the 20-minute freshness boundary no longer makes the number jump — the two sources now meet.
+- **A daily forecast was interpolated as if it were hourly.** `weather.get_forecasts` with `type: daily` — which the documentation offers for integrations without an hourly forecast — returns one entry per day carrying that day's *maximum*. 3.1.0 interpolated between those maxima, so a frame showed roughly the afternoon high all morning (~25 °C at 6 a.m. against a real 14 °C). Points more than 3 hours apart are no longer treated as neighbouring hours; with a coarse forecast the frame keeps showing the last measurement instead, with its age printed underneath as before.
+- The fallback to the last measurement no longer requires the forecast to be missing entirely — an unusable one (too coarse, or unparseable timestamps) now falls back the same way instead of showing `--°`. `--°` is still shown for the case it was meant for: a genuine hourly forecast whose last hour is already in the past.
+
 ## [3.1.0] – 2026
 
 ### Fixed

--- a/snapframe/README.md
+++ b/snapframe/README.md
@@ -469,8 +469,14 @@ The badge is driven by the same data as the weather screen, so it needs no extra
 `temperature` in `/weather-update` is only current at the moment Home Assistant pushes it. A frame that runs all day would otherwise keep showing the value from the morning push. So the frame decides for itself what to display:
 
 - **push younger than 20 minutes** → the pushed value is used as-is (it is a measurement)
-- **older than that** → the temperature is **interpolated from the hourly forecast** that arrived with it, so the number moves smoothly through the day instead of jumping on the hour
+- **older than that** → the temperature is **derived from the hourly forecast** that arrived with it, so the number moves smoothly through the day instead of jumping on the hour
 - **beyond the end of that forecast** (nothing pushed for ~12 h) → `--°`, and the badge hides rather than lying
+
+Only the *shape* of the forecast is used, never its absolute values. A forecast does not agree with the measurement beside it — OpenWeatherMap's hourly forecast commonly runs a degree or two away from the same integration's own current temperature — so the difference between the two at the moment of the push is carried forward. The displayed curve therefore passes through the last real measurement and tracks how much it has warmed or cooled since, instead of inheriting the forecast's bias.
+
+A forecast whose entries are more than 3 hours apart is not an hourly one — `type: daily` returns one entry per day carrying that day's *maximum* — so it is never interpolated. With a coarse forecast the frame keeps showing the last measurement, with its age underneath.
+
+> **The update automation has to keep running all day.** This is the single most common cause of a temperature that looks wrong: an automation triggered once in the morning (`trigger: time, at: "05:58:00"`) pushes one measurement and one 12-hour forecast, and everything after that is derived. The frame handles it, but a measurement always beats a derivation — use the `time_pattern` and `state` triggers below so a fresh one arrives every half hour. Note also that `forecast[:12]` covers only the next 12 hours, so a single morning push runs out by late afternoon and the frame falls back to `--°`.
 
 The weather screen prints the data's age underneath (`updated 12 min ago`, or `from the hourly forecast · updated 4 h ago`), so a stalled automation is visible instead of silent. The hourly strip likewise drops hours that have already passed, so the highlighted "now" card really is now.
 

--- a/snapframe/config.yaml
+++ b/snapframe/config.yaml
@@ -1,5 +1,5 @@
 name: "SnapFrame – Digital Photo Frame"
-version: "3.1.0"
+version: "3.1.1"
 slug: "snapframe"
 description: "Turn any old tablet or iPad into a smart digital photo frame. Watches an SMB share, converts HEIC/HEIF to JPG, and serves a fullscreen slideshow with albums, EXIF date/GPS overlay, swipe gestures, web upload, night mode, a motion-triggered weather screen and waste-collection reminders. Home Assistant ingress and MQTT discovery included."
 url: "https://github.com/emo546/ha-snapframe"

--- a/snapframe/rootfs/usr/share/snapframe/static/app.js
+++ b/snapframe/rootfs/usr/share/snapframe/static/app.js
@@ -667,11 +667,16 @@ function _hourlyPoints(hourly) {
   return pts;
 }
 
+// Nad týmto rozostupom už dva body nie sú susedné hodiny a interpolovať medzi
+// nimi nemá zmysel: denná predpoveď (`type: daily`) nesie denné MAXIMÁ, takže
+// interpolácia medzi nimi dá ráno letnú popoludňajšiu teplotu.
+var WEATHER_MAX_GAP_MS = 3 * 3600000;
+
 /** Teplota a podmienka pre `nowMs`, dopočítané z hodinovej predpovede.
- * Medzi dvoma hodinami sa teplota interpoluje lineárne, takže číslo na
- * obrazovke rastie plynulo namiesto skoku vždy o celej hodine.
- * Mimo rozsahu predpovede (viac než hodinu pred prvou alebo za poslednou)
- * vráti null – vtedy sa už nedá tvrdiť nič. */
+ * Medzi dvoma susednými hodinami sa teplota interpoluje lineárne, takže číslo
+ * na obrazovke rastie plynulo namiesto skoku vždy o celej hodine.
+ * Mimo rozsahu predpovede (viac než hodinu pred prvou alebo za poslednou),
+ * alebo keď sú body priďaleko od seba, vráti null. */
 function weatherFromHourly(hourly, nowMs) {
   var pts = _hourlyPoints(hourly), i, a, b, f;
   if (!pts.length) { return null; }
@@ -682,6 +687,7 @@ function weatherFromHourly(hourly, nowMs) {
   for (i = 0; i < pts.length - 1; i++) {
     a = pts[i]; b = pts[i + 1];
     if (nowMs >= a.t && nowMs <= b.t) {
+      if (b.t - a.t > WEATHER_MAX_GAP_MS) { return null; }
       f = (b.t === a.t) ? 0 : (nowMs - a.t) / (b.t - a.t);
       return {
         temperature: a.temp + (b.temp - a.temp) * f,
@@ -695,13 +701,39 @@ function weatherFromHourly(hourly, nowMs) {
 }
 
 var WEATHER_FRESH_SECS = 20 * 60;   // dokedy sa pushnutá hodnota berie ako aktuálna
+var WEATHER_MAX_ANCHOR = 5;         // °C – poistka proti nezmyselne veľkému posunu
+
+/** Je to naozaj hodinová predpoveď? Rozostup prvých dvoch bodov stačí –
+ * Home Assistant posiela body rovnomerne. */
+function _isHourly(pts) {
+  return pts.length >= 2 && (pts[1].t - pts[0].t) <= WEATHER_MAX_GAP_MS;
+}
+
+/** Rozdiel medzi meraním a predpoveďou v čase posledného pushu.
+ *
+ * Predpoveď a meranie sa systematicky líšia – u OpenWeatherMap beží hodinová
+ * predpoveď bežne o pár stupňov inak než jeho vlastná nameraná teplota. Keď
+ * sa z predpovede vzala absolútna hodnota, rám tú odchýlku ukazoval celý deň.
+ * Meranie z posledného pushu je jediné pevné číslo, ktoré máme, tak sa z
+ * predpovede berie len jej TVAR: o koľko sa odvtedy oteplilo alebo ochladilo.
+ * Vedľajší efekt je, že dopočítaná hodnota na meranie plynulo nadväzuje –
+ * pri prechode cez hranicu čerstvosti už teplota neposkočí. */
+function weatherAnchorOffset(d, age) {
+  if (d.temperature == null || age == null) { return 0; }
+  var atPush = weatherFromHourly(d.hourly, Date.now() - age * 1000);
+  if (!atPush) { return 0; }
+  var off = d.temperature - atPush.temperature;
+  if (off >  WEATHER_MAX_ANCHOR) { return  WEATHER_MAX_ANCHOR; }
+  if (off < -WEATHER_MAX_ANCHOR) { return -WEATHER_MAX_ANCHOR; }
+  return off;
+}
 
 /** Čo naozaj ukázať ako aktuálne počasie.
  *
  * `temperature` z /weather-update je aktuálna len v okamihu pushu; keď rám
  * beží celý deň a Home Assistant medzitým nič nepošle, ostane na obrazovke
  * ranná hodnota. Kým je push čerstvý, berieme ho (je to meranie), potom sa
- * teplota dopočítava z hodinovej predpovede, ktorá prišla s ním.
+ * teplota dopočítava z hodinovej predpovede ukotvenej na to meranie.
  * Vráti {temperature, condition, derived} alebo null, keď sa už nedá tvrdiť nič. */
 function currentWeather() {
   var d = weatherData;
@@ -710,13 +742,25 @@ function currentWeather() {
   if (d.temperature != null && (age == null || age <= WEATHER_FRESH_SECS)) {
     return { temperature: d.temperature, condition: d.condition || "", derived: false };
   }
-  var h = weatherFromHourly(d.hourly, Date.now());
+  var now = Date.now();
+  var h   = weatherFromHourly(d.hourly, now);
   if (h) {
-    return { temperature: h.temperature, condition: h.condition, derived: true };
+    return {
+      temperature: h.temperature + weatherAnchorOffset(d, age),
+      condition:   h.condition,
+      derived:     true
+    };
   }
-  // Bez hodinovej predpovede niet z čoho dopočítať – pushnutá hodnota je
-  // stále lepšia než nič a riadok s vekom pod ňou povie, aká je stará.
-  if (!_hourlyPoints(d.hourly).length && d.temperature != null) {
+  // Hodinová predpoveď existuje, ale „teraz“ je až za jej koncom – dáta sú
+  // preukázateľne neplatné a tvrdiť z nich teplotu by bolo klamstvo.
+  var pts = _hourlyPoints(d.hourly);
+  if (_isHourly(pts) && now > pts[pts.length - 1].t + 3600000) {
+    return null;
+  }
+  // Inak sa dopočítať nedá (žiadna predpoveď, alebo len hrubá/denná, ktorá
+  // nesie maximá a nie priebeh) – posledné meranie je stále to najlepšie, čo
+  // máme, a riadok s vekom pod ním povie, aké je staré.
+  if (d.temperature != null) {
     return { temperature: d.temperature, condition: d.condition || "", derived: false };
   }
   return null;


### PR DESCRIPTION
Fixes a regression from 3.1.0, reported as "the temperature is about 2 degrees too high".

## Root cause

3.1.0 falls back to the hourly forecast once the last push is older than 20 minutes — but it took the forecast's **absolute** value. A forecast does not agree with the measurement it sits beside: OpenWeatherMap's hourly forecast routinely runs a degree or two away from the same integration's own current temperature.

The reporter's automation pushes once a day (`trigger: time, at: "05:58:00"`), so the frame was in derived mode from 06:18 onward and showed that offset for the entire day.

## Fix — carry the measurement forward, not the forecast's numbers

The measurement is the only fixed number available, so the forecast now contributes only its **shape**. The difference between the measurement and the forecast *at the moment of the push* is carried forward:

```
displayed(t) = forecast(t) + (measured − forecast(t_push))
```

The curve therefore passes exactly through the last real measurement and tracks how much it has warmed or cooled since. The offset is clamped to ±5 °C so one odd reading cannot skew the display.

A welcome side effect: crossing the 20-minute freshness boundary no longer makes the number jump. The two sources now meet, where before they were a whole bias apart.

## Also fixed — a daily forecast was interpolated as if it were hourly

`weather.get_forecasts` with `type: daily`, which the documentation offers for integrations without an hourly forecast, returns one entry per day carrying that day's *maximum*. 3.1.0 interpolated between those maxima, so such a frame showed roughly the afternoon high all morning — about 25 °C at 6 a.m. against a real 14 °C.

Points more than 3 hours apart are no longer treated as neighbouring hours. A forecast too coarse to derive from falls back to the last measurement rather than to `--°`; that fallback no longer requires the forecast to be missing entirely. `--°` is kept for the case it was meant for — a genuine hourly forecast whose last hour has already passed.

**Update:** the gap check above only ran inside the pairwise interpolation loop. The two single-point extrapolation branches (just before the forecast's first point, just after its last) had no second point to compare against, so a daily forecast's single nearby point could still slip through unchecked and get shown as the current temperature — e.g. last measurement 14 °C, daily maximum 25 °C → 25 °C displayed. `weatherFromHourly()` now rejects a coarse or single-point forecast up front, before either branch runs, so this can no longer happen.

## Verification

Simulating the reporter's exact setup (push at 05:58 with a measured 14 °C against a forecast running ~2 °C warm):

| | 06:00 | 09:00 | 13:00 | 17:00 |
|---|---|---|---|---|
| reality | 14.0° | 19.0° | 25.0° | 18.0° |
| **after this fix** | 14.0° | 19.0° | 25.0° | 18.0° |

At the freshness boundary the bare forecast would show 16.32° against a held measurement of 14.00° — a 2.32° jump. Anchored, it shows 14.32°, which is the real warming over those 20 minutes rather than a bias.

Driven end-to-end in a browser on a 3-hour-old push: bare forecast 22.71°, anchored 19.86° (offset −2.86), badge and slide both rendering correctly.

105 tests pass, ruff and `node --check` clean.

## Docs

The README now states that only the forecast's shape is used, that a coarse forecast is never interpolated, and — as the most common cause of a wrong-looking temperature — that an automation triggered once in the morning leaves everything after it derived, plus the fact that `forecast[:12]` runs out by late afternoon.

Version 3.1.1.